### PR TITLE
output stacktrace

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -34,6 +34,7 @@ var confList = []string{
 
 var (
 	buildVersion string
+	buildHash    string
 	buildDate    string
 	goversion    string
 )
@@ -44,10 +45,13 @@ var (
 
 func showVersion() {
 	fmt.Println()
-	fmt.Println("build version: ", buildVersion)
+	if buildVersion != "" {
+		fmt.Println("build version: ", buildVersion)
+	} else {
+		fmt.Println("build version: ", buildHash)
+	}
 	fmt.Println("build date: ", buildDate)
 	fmt.Println("GO version: ", goversion)
-	os.Exit(128)
 }
 
 func main() {
@@ -77,6 +81,7 @@ func main() {
 
 	if vOption {
 		showVersion()
+		os.Exit(128)
 	}
 
 	conf.Set("404_img_path", *notFoundImagePath)

--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"runtime"
 
 	"github.com/livesense-inc/fanlin/lib/conf"
@@ -31,6 +32,26 @@ var confList = []string{
 	"~/.fanlin.cnf",
 }
 
+var (
+	buildVersion string
+	buildHash    string
+	buildDate    string
+	goversion    string
+)
+
+var (
+	vOption bool
+)
+
+func showVersion() {
+	fmt.Println()
+	fmt.Println("build version: ", buildVersion)
+	fmt.Println("build hash: ", buildVersion)
+	fmt.Println("build date: ", buildDate)
+	fmt.Println("GO version: ", goversion)
+	os.Exit(128)
+}
+
 func main() {
 	conf := func() *configure.Conf {
 		for _, confName := range confList {
@@ -53,7 +74,13 @@ func main() {
 	localImagePath := flag.String("li", conf.LocalImagePath(), "local image path")
 	maxProcess := flag.Int("cpu", conf.MaxProcess(), "max process.")
 	debug := flag.Bool("debug", false, "debug mode.")
+	flag.BoolVar(&vOption, "v", false, "version")
 	flag.Parse()
+
+	if vOption {
+		showVersion()
+	}
+
 	conf.Set("404_img_path", *notFoundImagePath)
 	conf.Set("error_log_path", *errorLogPath)
 	conf.Set("access_log_path", *accessLogPath)

--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -34,7 +34,6 @@ var confList = []string{
 
 var (
 	buildVersion string
-	buildHash    string
 	buildDate    string
 	goversion    string
 )
@@ -46,7 +45,6 @@ var (
 func showVersion() {
 	fmt.Println()
 	fmt.Println("build version: ", buildVersion)
-	fmt.Println("build hash: ", buildVersion)
 	fmt.Println("build date: ", buildDate)
 	fmt.Println("GO version: ", goversion)
 	os.Exit(128)

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -63,6 +63,14 @@ func (c *Conf) AccessLogPath() string {
 	return path.(string)
 }
 
+func (c *Conf) DebugLogPath() string {
+	path := c.c["debug_log_path"]
+	if path == nil {
+		path = "./debug.log"
+	}
+	return path.(string)
+}
+
 func (c *Conf) Port() int {
 	port := c.c["port"]
 	return convInterfaceToInt(port, 8080)

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -66,7 +66,7 @@ func (c *Conf) AccessLogPath() string {
 func (c *Conf) DebugLogPath() string {
 	path := c.c["debug_log_path"]
 	if path == nil {
-		path = "./debug.log"
+		path = "/dev/null"
 	}
 	return path.(string)
 }

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var devNull, _ = os.Open("/dev/null")
+
 func create404Page(w http.ResponseWriter, r *http.Request, conf *configure.Conf) {
 	q := query.NewQueryFromGet(r)
 
@@ -47,7 +49,6 @@ func writeDebugLog(err interface{}, debugFile string) {
 }
 
 func MainHandler(w http.ResponseWriter, r *http.Request, conf *configure.Conf, loggers map[string]logrus.Logger) {
-	devNull, _ := os.Open("/dev/null")
 	defer func() {
 		err := recover()
 		if err != nil {

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -36,7 +36,7 @@ func create404Page(w http.ResponseWriter, r *http.Request, conf *configure.Conf)
 }
 
 func writeDebugLog(err interface{}, debugFile string) {
-	stackWriter, _ := os.OpenFile(debugFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	stackWriter, _ := os.OpenFile(debugFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	t := time.Now()
 	stackWriter.Write([]byte("\n"))
 	stackWriter.Write([]byte("==========================================\n"))

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -36,7 +36,7 @@ func create404Page(w http.ResponseWriter, r *http.Request, conf *configure.Conf)
 }
 
 func writeDebugLog(err interface{}, debugFile string) {
-	stackWriter, _ := os.OpenFile(debugFile, os.O_APPEND|os.O_WRONLY, 0600)
+	stackWriter, _ := os.OpenFile(debugFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	t := time.Now()
 	stackWriter.Write([]byte("\n"))
 	stackWriter.Write([]byte("==========================================\n"))


### PR DESCRIPTION
- [x] @na-o-ys 

## abstract

fanlin wasn't able to output stacktrace.
because, it was added to the renovation.

## add config
* `debug_log_path` option
