### PR TITLE
timeout setting and use default http client in go.

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -100,6 +100,8 @@ func main() {
 		fmt.Println(conf)
 	}
 
+	http.DefaultClient.Timeout = conf.BackendRequestTimeout()
+
 	runtime.GOMAXPROCS(conf.MaxProcess())
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 type Conf struct {
@@ -93,6 +94,24 @@ func (c *Conf) DebugLogPath() string {
 		path = "/dev/null"
 	}
 	return path.(string)
+}
+
+func (c *Conf) BackendRequestTimeout() time.Duration {
+	tstr, ok := c.c["backeend_request_timeout"]
+	if !ok {
+		return 10 * time.Second
+	}
+
+	t, ok := tstr.(string)
+	if !ok {
+		return 10 * time.Second
+	}
+
+	d, err := time.ParseDuration(t)
+	if err != nil {
+		panic(err)
+	}
+	return d
 }
 
 func (c *Conf) Port() int {

--- a/lib/content/web/web.go
+++ b/lib/content/web/web.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"time"
 
 	"bytes"
 	"io"
@@ -15,10 +14,12 @@ import (
 
 var ua = fmt.Sprintf("Mozilla/5.0 (fanlin; arch: %s; OS: %s; Go version: %s) Go language Client/1.1 (KHTML, like Gecko) Version/1.0 fanlin", runtime.GOARCH, runtime.GOOS, runtime.Version())
 
+/*
 var client = http.Client{
 	Transport: &http.Transport{MaxIdleConnsPerHost: 64},
 	Timeout:   time.Duration(10) * time.Second,
 }
+*/
 
 var httpClient = Client{
 	Http: new(RealWebClient),
@@ -42,7 +43,7 @@ func (r *RealWebClient) Get(url string) (io.Reader, error) {
 	}
 	req.Header.Set("User-Agent", ua)
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, imgproxyerr.New(imgproxyerr.ERROR, err)
 	}

--- a/lib/content/web/web.go
+++ b/lib/content/web/web.go
@@ -14,13 +14,6 @@ import (
 
 var ua = fmt.Sprintf("Mozilla/5.0 (fanlin; arch: %s; OS: %s; Go version: %s) Go language Client/1.1 (KHTML, like Gecko) Version/1.0 fanlin", runtime.GOARCH, runtime.GOOS, runtime.Version())
 
-/*
-var client = http.Client{
-	Transport: &http.Transport{MaxIdleConnsPerHost: 64},
-	Timeout:   time.Duration(10) * time.Second,
-}
-*/
-
 var httpClient = Client{
 	Http: new(RealWebClient),
 }


### PR DESCRIPTION
# changes
Can be setting timeout duration.
It is defined of `backeend_request_timeout` param.
Format conforms to the duration format of go.
The default timeout duration is 10 seconds as usual.

ex. `{"backeend_request_timeout": "1h30m"}`

And I change using default http client.