### PR TITLE
Add to sort providers by priority

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -81,20 +81,23 @@ $ go test -cover ./...
         {
             "alias/0" : {
                 "type" : "web",
-                "src" : "http://aaa.com/bbb"
+                "src" : "http://aaa.com/bbb",
+                "priority" : 10
             }
         },
         {
             "alias/1" : {
                 "type" : "web",
-                "src" : "https://ccc.com"
+                "src" : "https://ccc.com",
+                "priority" : 20
             }
         },
         {
             "alias/3" : {
                 "type" : "s3",
                 "src" : "s3://bucket/path",
-                "region" : "ap-northeast-1"
+                "region" : "ap-northeast-1",
+                "priority" : 30
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -72,20 +72,23 @@ On Unix, Linux and OS X, fanlin programs read startup options from the following
         {
             "alias/0" : {
                 "type" : "web",
-                "src" : "http://aaa.com/bbb"
+                "src" : "http://aaa.com/bbb",
+                "priority" : 10
             }
         },
         {
             "alias/1" : {
                 "type" : "web",
-                "src" : "https://ccc.com"
+                "src" : "https://ccc.com",
+                "priority" : 20
             }
         },
         {
             "alias/3" : {
                 "type" : "s3",
                 "src" : "s3://bucket/path",
-                "region" : "ap-northeast-1"
+                "region" : "ap-northeast-1",
+                "priority" : 30
             }
         }
     ]

--- a/lib/content/content.go
+++ b/lib/content/content.go
@@ -21,7 +21,7 @@ type provider struct {
 
 var providers []provider
 
-var DEFAULT_PRIORITY float64 = 10.0
+const DEFAULT_PRIORITY float64 = 10.0
 
 func init() {
 	providers = nil

--- a/lib/content/content.go
+++ b/lib/content/content.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/livesense-inc/fanlin/lib/conf"
@@ -15,10 +16,12 @@ type Content struct {
 
 type provider struct {
 	alias string
-	meta  interface{}
+	meta  map[string]interface{}
 }
 
 var providers []provider
+
+var DEFAULT_PRIORITY float64 = 10.0
 
 func init() {
 	providers = nil
@@ -28,9 +31,19 @@ func getProviders(c *configure.Conf) []provider {
 	ret := make([]provider, 0, len(c.Providers()))
 	for _, p := range c.Providers() {
 		for alias, meta := range convertInterfaceToMap(p) {
-			ret = append(ret, provider{alias, meta})
+			m := convertInterfaceToMap(meta)
+			if _, ok := m["priority"]; !ok {
+				m["priority"] = DEFAULT_PRIORITY
+			}
+
+			ret = append(ret, provider{alias, m})
 		}
 	}
+
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].meta["priority"].(float64) < ret[j].meta["priority"].(float64)
+	})
+
 	return ret
 }
 
@@ -45,7 +58,7 @@ func getContent(urlPath string, p []provider) *Content {
 		return nil
 	}
 	targetProvider := p[index]
-	for k, v := range convertInterfaceToMap(targetProvider.meta) {
+	for k, v := range targetProvider.meta {
 		switch k {
 		case "src":
 			src := v.(string)


### PR DESCRIPTION
When alias is like `alias/a/b` and `alias/a`, the provider may not be selected properly.
Added priority to metadata and sort by that.