### PR TITLE
fix file buffer in s3 content.

### DIFF
--- a/lib/content/s3/s3.go
+++ b/lib/content/s3/s3.go
@@ -55,6 +55,7 @@ func GetImageBinary(c *content.Content) (io.Reader, error) {
 		if form, ok := c.Meta["norm_form"].(string); ok {
 			path, err = NormalizePath(path, form)
 			if err != nil {
+				return nil, err
 			}
 		}
 		return s3GetSourceFunc(region, bucket, path, file)

--- a/lib/content/source.go
+++ b/lib/content/source.go
@@ -2,7 +2,6 @@ package content
 
 import (
 	"errors"
-	"log"
 
 	"io"
 
@@ -36,7 +35,6 @@ func sniff(c *Content) source {
 }
 
 func GetImageBinary(c *Content) (io.Reader, error) {
-	log.Println(c)
 	f := sniff(c)
 	if f.getImageBinary == nil {
 		return nil, imgproxyerr.New(imgproxyerr.WARNING, errors.New("unknown content type"))

--- a/lib/content/source.go
+++ b/lib/content/source.go
@@ -2,9 +2,11 @@ package content
 
 import (
 	"errors"
+	"log"
+
+	"io"
 
 	"github.com/livesense-inc/fanlin/lib/error"
-	"io"
 )
 
 type source struct {
@@ -34,6 +36,7 @@ func sniff(c *Content) source {
 }
 
 func GetImageBinary(c *Content) (io.Reader, error) {
+	log.Println(c)
 	f := sniff(c)
 	if f.getImageBinary == nil {
 		return nil, imgproxyerr.New(imgproxyerr.WARNING, errors.New("unknown content type"))


### PR DESCRIPTION
Buffering images on file complicates deletion timing.
The deletion timing was too early this time.
Change from file buffer to memory buffer.