### PR TITLE
Add aws credentials for s3

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -90,7 +90,8 @@ $ go test -cover ./...
                 "type" : "s3",
                 "src" : "s3://bucket/path",
                 "region" : "ap-northeast-1",
-                "priority" : 30
+                "priority" : 30,
+                "use_env_credential": true
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ On Unix, Linux and OS X, fanlin programs read startup options from the following
                 "type" : "s3",
                 "src" : "s3://bucket/path",
                 "region" : "ap-northeast-1",
-                "priority" : 30
+                "priority" : 30,
+                "use_env_credential": true
             }
         }
     ]


### PR DESCRIPTION
Enable access to S3 from servers (ON-PREMISES server, etc.) without ACL.

By define the privider like bellow,  and add ENV variables of `AWS_ACCESS_KEY_ID` AND `AWS_SECRET_ACCESS_KEY`, you can download files from private S3 buckets from ON-PREMISES servers.

```
{   
    ...
    "alias/3" : {
        "type" : "s3",
        "src" : "s3://bucket/path",
        "region" : "ap-northeast-1",
        "priority" : 30,
        "use_env_credential": true
    }
    ...
}
```