### PR TITLE
[DO NOT MERGE] Add profiling task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,5 @@ _testmain.go
 .vscode
 
 vendor/
-
+/*.out
+/*.test

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ test:
 	@go clean -testcache
 	@go test -race ./...
 
+bench:
+	@go test -bench=. -benchmem -run=NONE ./...
+
 prof: PKG ?= handler
 prof: TYPE ?= mem
 prof:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+MAKEFLAGS += --warn-undefined-variables
+SHELL     := /bin/bash -e -u -o pipefail
+
+echo:
+	@echo Hi
+
+test:
+	@go clean -testcache
+	@go test -race ./...
+
+prof: PKG ?= handler
+prof: TYPE ?= mem
+prof:
+	@if [[ -z "${PKG}" ]]; then echo 'empty variable: PKG'; exit 1; fi
+	@if [[ -z "${TYPE}" ]]; then echo 'empty variable: TYPE'; exit 1; fi
+	@if [[ ! -d "./lib/${PKG}" ]]; then echo 'package not found: ${PKG}'; exit 1; fi
+	@go test -bench=. -run=NONE -${TYPE}profile=${TYPE}.out ./lib/${PKG}
+	@go tool pprof -text -nodecount=10 ./${PKG}.test ${TYPE}.out

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -40,13 +40,20 @@ func (w *NullResponseWriter) WriteHeader(statusCode int) {
 func BenchmarkMainHandler(b *testing.B) {
 	w := NewNullResponseWriter()
 
+	q := url.Values{}
+	q.Set("w", "512")
+	q.Set("h", "512")
+	//q.Set("rgb", "100,100,100")
+	q.Set("quality", "80")
+
 	r := &http.Request{
 		RemoteAddr: "127.0.0.1",
 		Proto:      "HTTP/1.1",
 		Method:     http.MethodGet,
 		Host:       "127.0.0.1:8080",
 		URL: &url.URL{
-			Path: "/test/master/granada-jp0802/858.jpg",
+			Path:     "/test/master/granada-jp0802/858.jpg",
+			RawQuery: q.Encode(),
 		},
 		Header: http.Header{
 			"Content-Type": []string{"application/x-www-form-urlencoded"},

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	configure "github.com/livesense-inc/fanlin/lib/conf"
+	"github.com/sirupsen/logrus"
+)
+
+// NullResponseWriter is a struct
+type NullResponseWriter struct {
+	h          http.Header
+	b          io.Writer
+	StatusCode int
+}
+
+// NewNullResponseWriter returns a instance of NullResponseWriter
+func NewNullResponseWriter() *NullResponseWriter {
+	return &NullResponseWriter{h: http.Header{}, b: io.Discard}
+}
+
+// Header returns headers
+func (w *NullResponseWriter) Header() http.Header {
+	return w.h
+}
+
+// Write writes bytes to response writer
+func (w *NullResponseWriter) Write(p []byte) (int, error) {
+	return w.b.Write(p)
+}
+
+// WriteHeader updates the status code
+func (w *NullResponseWriter) WriteHeader(statusCode int) {
+	w.StatusCode = statusCode
+}
+
+func BenchmarkMainHandler(b *testing.B) {
+	w := NewNullResponseWriter()
+
+	r := &http.Request{
+		RemoteAddr: "127.0.0.1",
+		Proto:      "HTTP/1.1",
+		Method:     http.MethodGet,
+		Host:       "127.0.0.1:8080",
+		URL: &url.URL{
+			Path: "/test/master/granada-jp0802/858.jpg",
+		},
+		Header: http.Header{
+			"Content-Type": []string{"application/x-www-form-urlencoded"},
+		},
+	}
+
+	c := configure.NewConfigure("test.json")
+	if c == nil {
+		b.Fatal("Failed to build config")
+	}
+
+	stdOut := logrus.New()
+	stdOut.Out = io.Discard
+	stdErr := logrus.New()
+	stdErr.Out = io.Discard
+	l := map[string]logrus.Logger{"access": *stdOut, "err": *stdErr}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MainHandler(w, r, c, l)
+		if w.StatusCode != 200 {
+			b.Fatalf("want: 200, got: %d", w.StatusCode)
+		}
+	}
+}

--- a/lib/handler/test.json
+++ b/lib/handler/test.json
@@ -1,0 +1,18 @@
+{
+    "port": 8080,
+    "local_image_path": "../../img/",
+    "max_width": 1000,
+    "max_height": 1000,
+    "404_img_path": "../../img/404.png",
+    "access_log_path": "/dev/null",
+    "error_log_path": "/dev/stdout",
+    "debug_log_path": "/dev/stdout",
+    "user_agent": "Mozilla/5.0 (Livesense; Lvimg; http://localhost)",
+    "providers": [{
+            "/test/": {
+                "type": "web",
+                "src": "https://lvimg.jp/job/img/job_pict"
+            }
+        }
+    ]
+}

--- a/lib/handler/test.json
+++ b/lib/handler/test.json
@@ -5,9 +5,12 @@
     "max_height": 1000,
     "404_img_path": "../../img/404.png",
     "access_log_path": "/dev/null",
-    "error_log_path": "/dev/stdout",
-    "debug_log_path": "/dev/stdout",
-    "user_agent": "Mozilla/5.0 (Livesense; Lvimg; http://localhost)",
+    "error_log_path": "/dev/null",
+    "debug_log_path": "/dev/null",
+    "user_agent": "Mozilla/5.0 (Livesense; Fanlin Test; http://localhost)",
+    "use_ml_cmyk_converter": true,
+    "ml_cmyk_converter_network_file_path": "../../network.json",
+    "use_server_timing": true,
     "providers": [{
             "/test/": {
                 "type": "web",


### PR DESCRIPTION
@mom0tomo 

```
$ make prof
read configure. : /home/kasuga/vcs/fanlin/lib/handler/test.json
goos: linux
goarch: amd64
pkg: github.com/livesense-inc/fanlin/lib/handler
cpu: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
BenchmarkMainHandler-8          read configure. : /home/kasuga/vcs/fanlin/lib/handler/test.json
read configure. : /home/kasuga/vcs/fanlin/lib/handler/test.json
       3         503811938 ns/op
PASS
ok      github.com/livesense-inc/fanlin/lib/handler     3.046s
File: handler.test
Build ID: 242a96d579f93dfe6b67ee3829d52fbe41eb1ecf
Type: alloc_space
Time: Mar 2, 2023 at 11:14am (JST)
Showing nodes accounting for 612.67MB, 98.39% of 622.72MB total
Dropped 70 nodes (cum <= 3.11MB)
Showing top 10 nodes out of 39
      flat  flat%   sum%        cum   cum%
  307.55MB 49.39% 49.39%   307.55MB 49.39%  github.com/nfnt/resize.imageYCbCrToYCC
  155.39MB 24.95% 74.34%   155.39MB 24.95%  image.NewYCbCr
   97.14MB 15.60% 89.94%    97.14MB 15.60%  bytes.growSlice
   33.56MB  5.39% 95.33%    33.56MB  5.39%  github.com/nfnt/resize.newYCC
   19.03MB  3.06% 98.39%    19.03MB  3.06%  bufio.(*Reader).ReadBytes
         0     0% 98.39%    46.38MB  7.45%  bufio.(*Reader).Read
         0     0% 98.39%    50.76MB  8.15%  bytes.(*Buffer).ReadFrom
         0     0% 98.39%    46.38MB  7.45%  bytes.(*Buffer).Write
         0     0% 98.39%    97.14MB 15.60%  bytes.(*Buffer).grow
         0     0% 98.39%    50.76MB  8.15%  github.com/livesense-inc/fanlin/lib/content.GetImageBinary
```

https://pkg.go.dev/golang.org/x/net/netutil

> LimitListener returns a Listener that accepts at most n simultaneous connections from the provided Listener.