### PR TITLE
output logs to STDOUT

### DIFF
--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -14,6 +15,7 @@ func NewLogger(path string) *logrus.Logger {
 	if err != nil {
 		logger.Fatalln("Can not create log file: ", path)
 	}
-	logger.Out = logFile
+	mw := io.MultiWriter(os.Stdout, logFile)
+	logger.Out = mw
 	return logger
 }


### PR DESCRIPTION
resolve #40
Assuming that the system will be started in a container environment, logs are now sent out to standard output as well as to files.

***

コンテナ環境で起動することを想定し、ログをファイルだけでなく標準出力にも出すようにしました。