### PR TITLE
Add a note to README that logs can be output to standard output

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -99,6 +99,10 @@ $ go test -cover ./...
 }
 ```
 
+## ログの出力先を制御する
+設定項目の`access_log_path`/`error_log_path`/`debug_log_path`にパスを指定することで、それぞれのログをファイルに出力できます。
+標準出力にログを出力したい場合は、`/dev/stdout`を指定してください。
+
 ## WebPフォーマットの利用方法と制限事項
 fanlinへのリクエストに `webp=true` getパラメータを付与することで、WebPフォーマットの画像を返すことが出来ます.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ On Unix, Linux and macOS, fanlin programs read startup options from the followin
 }
 ```
 
+## Controling where logs are output to
+You can output each log to a file by specifying the path in `access_log_path`/`error_log_path`/`debug_log_path`.
+If you want to output logs to standard output, specify `/dev/stdout`.
+
 ## Using WebP and Limitations
 You can get WebP image format with GET parameter `webp=true` requeest.
 


### PR DESCRIPTION
READMEにログを標準出力に出力することができる旨を追記する

resolve #40 

Thanks to @supercaracal, I learned that logs can be output to stdout.
I added it to the README as it would be useful.