### PR TITLE
ci: remove an obsolete directive from GoReleaser settings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,5 +19,3 @@ builds:
 archives:
   - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}-v{{ . }}{{ end }}'
     format: binary
-    replacements:
-      amd64: x86_64


### PR DESCRIPTION
The following job was failed in CI.
https://github.com/livesense-inc/fanlin/actions/runs/7244252101/job/19732285416

> line 22: field replacements not found in type config.Archive

It seems that the directive was deleted from GoReleaser settings. On second thought, I think we don't have to rename executable files.