### PR TITLE
ci: add a main.go path to the setting of GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,7 @@ builds:
       - linux
     goarch:
       - amd64
+    main: ./cmd/fanlin
 
 # https://goreleaser.com/customization/archive/
 archives:


### PR DESCRIPTION
https://github.com/livesense-inc/fanlin/actions/runs/7244447066/job/19732789438

> error=build for fanlin does not contain a main function

* #49
* #50