### PR TITLE
ci: print glibc version in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,9 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Print libc version
+        run: ldd --version
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
Since we depend on glibc for the WebP conversion, we can't disable cgo. There may be an error to execute binary when glibc versions are different between build-environment and execute-environment. So I added a step to the release workflow to be able to recognize the glibc version in build-environment.