### PR TITLE
Add max-clients option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ _testmain.go
 vendor/
 /server
 /fanlin.json
+/*.log

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/rwcarlsen/goexif v0.0.0-20150520140647-709fab3d192d
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/image v0.0.0-20170322222000-c0851fbc5b92
+	golang.org/x/net v0.10.0
 	golang.org/x/text v0.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ golang.org/x/image v0.0.0-20170322222000-c0851fbc5b92 h1:AloAkWcniQLRH6BBDYmfDDL
 golang.org/x/image v0.0.0-20170322222000-c0851fbc5b92/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -3,7 +3,7 @@ package configure
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -60,6 +60,18 @@ func (c *Conf) EnableMetricsEndpoint() bool {
 		panic("'enable_metrics_endpoint' parameter is incorrect")
 	}
 	return r
+}
+
+func (c *Conf) MaxClients() int {
+	b, ok := c.c["max_clients"]
+	if !ok {
+		return 0
+	}
+	n, ok := b.(float64)
+	if !ok {
+		panic("'max_clients' parameter is incorrect")
+	}
+	return int(n)
 }
 
 func (c *Conf) Set(k string, v interface{}) {
@@ -272,7 +284,7 @@ func (c *Conf) includeConfigure(mainConfPath string, pathList []string) {
 
 func NewConfigure(confPath string) *Conf {
 	var conf map[string]interface{}
-	bin, err := ioutil.ReadFile(confPath)
+	bin, err := os.ReadFile(confPath)
 	if err != nil {
 		fmt.Println(err)
 		return nil

--- a/lib/conf/conf_test.go
+++ b/lib/conf/conf_test.go
@@ -72,4 +72,12 @@ func TestReadConfigure(t *testing.T) {
 			t.Fatalf("value is %v", ok)
 		}
 	}()
+
+	func() {
+		fmt.Println("max_clients test")
+		n := conf.MaxClients()
+		if n != 50 {
+			t.Fatalf("value is %d", n)
+		}
+	}()
 }

--- a/lib/test/test_conf.json
+++ b/lib/test/test_conf.json
@@ -5,6 +5,7 @@
     "max_height": 5000,
     "use_server_timing": true,
     "enable_metrics_endpoint": true,
+    "max_clients": 50,
     "externals": [{
             "example": "http://example.com/"
         },


### PR DESCRIPTION
I'd say that a feature of limiting request concurrency is a nice-to-have option for the stability.

* https://cs.opensource.google/go/x/net/+/master:netutil/listen.go
* https://github.com/golang/go/blob/d49a14c6092ba30d0afbdaa06a24016ff1fe2a82/src/net/http/server.go#L3258-L3291