### PR TITLE
Remove not implemented options

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -76,7 +76,6 @@ func main() {
 	accessLogPath := flag.String("log", conf.AccessLogPath(), "access log path")
 	port := flag.Int("p", conf.Port(), "port")
 	port = flag.Int("port", *port, "port")
-	localImagePath := flag.String("li", conf.LocalImagePath(), "local image path")
 	maxProcess := flag.Int("cpu", conf.MaxProcess(), "max process.")
 	debug := flag.Bool("debug", false, "debug mode.")
 	flag.BoolVar(&vOption, "v", false, "version")
@@ -91,7 +90,6 @@ func main() {
 	conf.Set("error_log_path", *errorLogPath)
 	conf.Set("access_log_path", *accessLogPath)
 	conf.Set("port", *port)
-	conf.Set("local_image_path", *localImagePath)
 	conf.Set("max_process", *maxProcess)
 
 	loggers := map[string]*logrus.Logger{

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -155,14 +155,6 @@ func (c *Conf) Port() int {
 	return convInterfaceToInt(port, 8080)
 }
 
-func (c *Conf) LocalImagePath() string {
-	path := c.c["local_image_path"]
-	if path == nil {
-		path = "./"
-	}
-	return path.(string)
-}
-
 func (c *Conf) MaxSize() (uint, uint) {
 	width := c.c["max_width"]
 	height := c.c["max_height"]
@@ -172,52 +164,9 @@ func (c *Conf) MaxSize() (uint, uint) {
 	return uint(w), uint(h)
 }
 
-func (c *Conf) Externals() map[string]string {
-	externals := c.c["externals"].([]interface{})
-	if externals == nil {
-		return map[string]string{}
-	}
-	externalsBuffer := map[string]string{}
-	for _, external := range externals {
-		for k, v := range external.(map[string]interface{}) {
-			externalsBuffer[k] = v.(string)
-		}
-	}
-	return externalsBuffer
-}
-
 func (c *Conf) MaxProcess() int {
 	maxProcess := c.c["max_process"]
 	return convInterfaceToInt(maxProcess, runtime.NumCPU())
-}
-
-func (c *Conf) S3BucketName() string {
-	name := c.c["s3_bucket_name"]
-
-	if n, ok := name.(string); ok {
-		if len(n) > 0 {
-			return n
-		}
-		return ""
-	}
-	return ""
-}
-
-// S3Region returns the set of "s3_region".
-// And default values "ap-northeast-1"
-func (c *Conf) S3Region() string {
-	if region, ok := c.c["s3_region"].(string); ok {
-		if region == "Tokyo" ||
-			region == "tokyo" ||
-			region == "asia-pacific" ||
-			region == "Asia pacific" ||
-			region == "asia pacific" {
-			return "ap-northeast-1"
-		}
-
-		return region
-	}
-	return "ap-northeast-1"
 }
 
 func convInterfaceToInt(v interface{}, exception int) int {

--- a/lib/conf/conf_test.go
+++ b/lib/conf/conf_test.go
@@ -9,9 +9,6 @@ var testConfig = "../test/test_conf.json"
 
 func TestReadConfigure(t *testing.T) {
 	conf := NewConfigure(testConfig)
-	testExterls := func() map[string]string {
-		return map[string]string{"example": "http://example.com/"}
-	}()
 	func() {
 		fmt.Println("test conf struct all.")
 		if conf == nil {
@@ -27,13 +24,6 @@ func TestReadConfigure(t *testing.T) {
 	}()
 
 	func() {
-		fmt.Println("local image path test.")
-		if conf.LocalImagePath() != "../img/" {
-			t.Fatalf("value is %v", conf.LocalImagePath())
-		}
-	}()
-
-	func() {
 		fmt.Println("max size test")
 		w, h := conf.MaxSize()
 		if w != 5000 {
@@ -41,19 +31,6 @@ func TestReadConfigure(t *testing.T) {
 		}
 		if h != 5000 {
 			t.Fatalf("value is %v", h)
-		}
-	}()
-
-	func() {
-		fmt.Println("externals test.")
-		externals := conf.Externals()
-		if externals == nil {
-			t.Fatalf("value is %v", nil)
-		}
-		for k, v := range testExterls {
-			if v != externals[k] {
-				t.Fatalf("k: %v, v: %v", k, externals[k])
-			}
 		}
 	}()
 

--- a/lib/test/test_conf.json
+++ b/lib/test/test_conf.json
@@ -1,16 +1,8 @@
 {
     "port": 8080,
-    "local_image_path": "../img/",
     "max_width": 5000,
     "max_height": 5000,
     "use_server_timing": true,
     "enable_metrics_endpoint": true,
-    "max_clients": 50,
-    "externals": [{
-            "example": "http://example.com/"
-        },
-        {
-            "test/test": "http://example.com/"
-        }
-    ]
+    "max_clients": 50
 }

--- a/lib/test/test_conf3.json
+++ b/lib/test/test_conf3.json
@@ -1,8 +1,5 @@
 {
   "port": 8080,
-  "local_image_path": "../img/",
   "max_width": 5000,
-  "max_height": 5000,
-  "externals": [
-  ]
+  "max_height": 5000
 }

--- a/lib/test/test_conf4.json
+++ b/lib/test/test_conf4.json
@@ -1,8 +1,5 @@
 {
   "port": 8080,
-  "local_image_path": "../img/",
   "max_width": 5000,
-  "max_height": 5000,
-  "externals": [
-  ]
+  "max_height": 5000
 }


### PR DESCRIPTION
It looks to me that the following options were aggregated to the `providers` directive. Correct me if I'm wrong.

* `local_image_path`
* `s3_bucket_name`
* `s3_region`

Also, I'm not pretty sure how the `externals` option effects this application. Either way, there were no implementation for it.