### PR TITLE
Add benchmark and profiling facilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,11 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libaom-dev
+
       - name: Download modules
         run: go mod download
 
@@ -104,6 +109,11 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libaom-dev
 
       - name: Download modules
         run: go mod download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,51 @@ jobs:
         with:
           version: "latest"
           install-go: false
+
+  benchmark:
+    name: Benchmark
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run benchmark
+        run: make bench
+
+  profiling:
+    name: Profiling
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ["handler"]
+        type: ["cpu", "block", "mem"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run
+        run: make prof
+        env:
+          PKG: ${{ matrix.package }}
+          TYPE: ${{ matrix.type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Download modules
         run: go mod download
 
-      - name: Run
+      - name: Run profiling
         run: make prof
         env:
           PKG: ${{ matrix.package }}

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ vendor/
 /server
 /fanlin.json
 /*.log
+/*.out
+/*.test
+__debug_bin

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ clean:
 	@unlink fanlin.json || true
 	@rm -f cmd/fanlin/server cmd/fanlin/fanlin.json
 
-.PHONY: build cmd/fanlin/server run test lint clean
+.PHONY: build cmd/fanlin/server run test lint bench prof clean

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,18 @@ test:
 lint:
 	@go vet ./...
 
+bench:
+	@go test -bench=. -benchmem -run=NONE ./...
+
+prof: PKG ?= handler
+prof: TYPE ?= mem
+prof:
+	@if [ -z "${PKG}" ]; then echo 'empty variable: PKG'; exit 1; fi
+	@if [ -z "${TYPE}" ]; then echo 'empty variable: TYPE'; exit 1; fi
+	@if [ ! -d "./lib/${PKG}" ]; then echo 'package not found: ${PKG}'; exit 1; fi
+	@go test -bench=. -run=NONE -${TYPE}profile=${TYPE}.out ./lib/${PKG}
+	@go tool pprof -text -nodecount=10 ./${PKG}.test ${TYPE}.out
+
 clean:
 	@unlink fanlin.json || true
 	@rm -f cmd/fanlin/server cmd/fanlin/fanlin.json

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
 
 	configure "github.com/livesense-inc/fanlin/lib/conf"
 	helper "github.com/livesense-inc/fanlin/lib/test"
+	"github.com/sirupsen/logrus"
 )
 
 func TestMakeMetricsHandler(t *testing.T) {
@@ -24,5 +26,49 @@ func TestMakeMetricsHandler(t *testing.T) {
 	h.ServeHTTP(w, r)
 	if w.StatusCode() != http.StatusOK {
 		t.Errorf("want=%d, got=%d", http.StatusOK, w.StatusCode())
+	}
+}
+
+func BenchmarkMainHandler(b *testing.B) {
+	c := configure.NewConfigure("../test/test_conf9.json")
+	if c == nil {
+		b.Fatal("Failed to build config")
+	}
+
+	w := helper.NewNullResponseWriter()
+	r := &http.Request{
+		RemoteAddr: "127.0.0.1",
+		Proto:      "HTTP/1.1",
+		Method:     http.MethodGet,
+		Host:       "127.0.0.1:3000",
+		URL: &url.URL{
+			Path: "/Lenna.jpg",
+			RawQuery: func() string {
+				q := url.Values{}
+				q.Set("w", "300")
+				q.Set("h", "200")
+				return q.Encode()
+			}(),
+		},
+		Header: http.Header{
+			"Content-Type": []string{"application/x-www-form-urlencoded"},
+		},
+	}
+
+	stdOut := logrus.New()
+	stdOut.Out = io.Discard
+	stdErr := logrus.New()
+	stdErr.Out = io.Discard
+	l := map[string]*logrus.Logger{"access": stdOut, "err": stdErr}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MainHandler(w, r, c, l)
+		if w.StatusCode() != 200 {
+			b.Fatalf("want: 200, got: %d", w.StatusCode())
+		}
+		if w.BodySize() == 0 {
+			b.Fatal("empty response body")
+		}
 	}
 }

--- a/lib/test/helper.go
+++ b/lib/test/helper.go
@@ -14,14 +14,15 @@ const (
 
 // NullResponseWriter is a struct
 type NullResponseWriter struct {
-	h  http.Header
-	b  io.Writer
-	sc int
+	h     http.Header
+	b     io.Writer
+	bSize int
+	sc    int
 }
 
 // NewNullResponseWriter returns a instance of NullResponseWriter
 func NewNullResponseWriter() *NullResponseWriter {
-	return &NullResponseWriter{h: http.Header{}, b: io.Discard}
+	return &NullResponseWriter{h: http.Header{}, b: io.Discard, sc: http.StatusOK}
 }
 
 // Header returns headers
@@ -31,6 +32,7 @@ func (w *NullResponseWriter) Header() http.Header {
 
 // Write writes bytes to response writer
 func (w *NullResponseWriter) Write(p []byte) (int, error) {
+	w.bSize += len(p)
 	return w.b.Write(p)
 }
 
@@ -42,6 +44,11 @@ func (w *NullResponseWriter) WriteHeader(statusCode int) {
 // StatusCode returns a status code
 func (w *NullResponseWriter) StatusCode() int {
 	return w.sc
+}
+
+// BodySize returns a size of the body
+func (w *NullResponseWriter) BodySize() int {
+	return w.bSize
 }
 
 // NullLogger returns a instance of log.Logger

--- a/lib/test/test_conf9.json
+++ b/lib/test/test_conf9.json
@@ -1,0 +1,17 @@
+{
+    "port": 3000,
+    "max_width": 3000,
+    "max_height": 3000,
+    "404_img_path": "../../img/404.png",
+    "access_log_path": "/dev/null",
+    "error_log_path": "/dev/null",
+    "max_clients": 50,
+    "providers": [
+        {
+            "/" : {
+                "type" : "local",
+                "src" : "../test/img"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
I added benchmark and profiling facilities to get a proof of a performance tuning. Also I set the both to a workflow in CI. I think we became to be able to review tunings were whether legit or not. As a context, I have a plan to try to lessen load of GC by using [sync.Pool](https://pkg.go.dev/sync#Pool) for some buffers in the future.