### PR TITLE
[WIP] Lessen load of GC

### DIFF
--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -21,7 +21,7 @@ func (c *Conf) UseMLCMYKConverter() bool {
 	}
 	r, ok := b.(bool)
 	if !ok {
-		panic("'use_ml_cmyk_converter' parameter is incorrect")
+		return false
 	}
 	return r
 }
@@ -33,7 +33,7 @@ func (c *Conf) MLCMYKConverterNetworkFilePath() string {
 	}
 	s, ok := i.(string)
 	if !ok {
-		panic("'ml_cmyk_converter_network_file_path' parameter is incorrect")
+		return ""
 	}
 	return s
 }
@@ -45,7 +45,7 @@ func (c *Conf) UseServerTiming() bool {
 	}
 	r, ok := b.(bool)
 	if !ok {
-		panic("'use_server_timing' parameter is incorrect")
+		return false
 	}
 	return r
 }
@@ -57,7 +57,7 @@ func (c *Conf) EnableMetricsEndpoint() bool {
 	}
 	r, ok := b.(bool)
 	if !ok {
-		panic("'enable_metrics_endpoint' parameter is incorrect")
+		return false
 	}
 	return r
 }
@@ -69,7 +69,7 @@ func (c *Conf) MaxClients() int {
 	}
 	n, ok := b.(float64)
 	if !ok {
-		panic("'max_clients' parameter is incorrect")
+		return 50
 	}
 	return int(n)
 }
@@ -145,7 +145,7 @@ func (c *Conf) BackendRequestTimeout() time.Duration {
 
 	d, err := time.ParseDuration(t)
 	if err != nil {
-		panic(err)
+		return 10 * time.Second
 	}
 	return d
 }

--- a/lib/content/content.go
+++ b/lib/content/content.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/livesense-inc/fanlin/lib/conf"
+	configure "github.com/livesense-inc/fanlin/lib/conf"
 )
 
 type Content struct {

--- a/lib/content/local/local.go
+++ b/lib/content/local/local.go
@@ -10,13 +10,12 @@ import (
 	"github.com/livesense-inc/fanlin/lib/content"
 )
 
-func GetImageBinary(c *content.Content, b []byte) (io.Reader, error) {
+func GetImageBinary(c *content.Content, buf *bytes.Buffer) (io.Reader, error) {
 	f, err := os.Open(path.Clean(c.SourcePlace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open a file: %s: %w", c.SourcePlace, err)
 	}
 	defer f.Close()
-	buf := bytes.NewBuffer(b)
 	if _, err := io.Copy(buf, f); err != nil {
 		return nil, err
 	}

--- a/lib/content/local/local.go
+++ b/lib/content/local/local.go
@@ -10,17 +10,17 @@ import (
 	"github.com/livesense-inc/fanlin/lib/content"
 )
 
-func GetImageBinary(c *content.Content) (io.Reader, error) {
+func GetImageBinary(c *content.Content, b []byte) (io.Reader, error) {
 	f, err := os.Open(path.Clean(c.SourcePlace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open a file: %s: %w", c.SourcePlace, err)
 	}
 	defer f.Close()
-	var b bytes.Buffer
-	if _, err := io.Copy(&b, f); err != nil {
+	buf := bytes.NewBuffer(b)
+	if _, err := io.Copy(buf, f); err != nil {
 		return nil, err
 	}
-	return &b, nil
+	return buf, nil
 }
 
 func init() {

--- a/lib/content/local/local.go
+++ b/lib/content/local/local.go
@@ -10,16 +10,16 @@ import (
 	"github.com/livesense-inc/fanlin/lib/content"
 )
 
-func GetImageBinary(c *content.Content, buf *bytes.Buffer) (io.Reader, error) {
+func GetImageBinary(c *content.Content, b *bytes.Buffer) (io.Reader, error) {
 	f, err := os.Open(path.Clean(c.SourcePlace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open a file: %s: %w", c.SourcePlace, err)
 	}
 	defer f.Close()
-	if _, err := io.Copy(buf, f); err != nil {
+	if _, err := io.Copy(b, f); err != nil {
 		return nil, err
 	}
-	return buf, nil
+	return b, nil
 }
 
 func init() {

--- a/lib/content/local/local_test.go
+++ b/lib/content/local/local_test.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"bytes"
 	"io"
 	"testing"
 
@@ -11,7 +12,7 @@ func TestGetImageBinary(t *testing.T) {
 	c := content.Content{
 		SourcePlace: "../../test/img/Lenna.jpg",
 	}
-	if r, err := GetImageBinary(&c, []byte{}); err != nil {
+	if r, err := GetImageBinary(&c, new(bytes.Buffer)); err != nil {
 		t.Fatal(err)
 	} else {
 		if b, err := io.ReadAll(r); err != nil {

--- a/lib/content/local/local_test.go
+++ b/lib/content/local/local_test.go
@@ -11,7 +11,7 @@ func TestGetImageBinary(t *testing.T) {
 	c := content.Content{
 		SourcePlace: "../../test/img/Lenna.jpg",
 	}
-	if r, err := GetImageBinary(&c); err != nil {
+	if r, err := GetImageBinary(&c, []byte{}); err != nil {
 		t.Fatal(err)
 	} else {
 		if b, err := io.ReadAll(r); err != nil {

--- a/lib/content/s3/s3.go
+++ b/lib/content/s3/s3.go
@@ -19,11 +19,11 @@ import (
 var s3GetSourceFunc = getS3ImageBinary
 
 // Test dedicated function
-func setS3GetFunc(f func(cfg *aws.Config, bucket, key string) (io.Reader, error)) {
+func setS3GetFunc(f func(cfg *aws.Config, bucket, key string, b []byte) (io.Reader, error)) {
 	s3GetSourceFunc = f
 }
 
-func GetImageBinary(c *content.Content) (io.Reader, error) {
+func GetImageBinary(c *content.Content, b []byte) (io.Reader, error) {
 	if c == nil {
 		return nil, errors.New("content is nil")
 	}
@@ -50,7 +50,7 @@ func GetImageBinary(c *content.Content) (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		return s3GetSourceFunc(&cfg, bucket, path)
+		return s3GetSourceFunc(&cfg, bucket, path, b)
 	}
 	return nil, imgproxyerr.New(imgproxyerr.ERROR, errors.New("can not parse configure"))
 }
@@ -69,9 +69,9 @@ func NormalizePath(path string, form string) (string, error) {
 	return "", imgproxyerr.New(imgproxyerr.WARNING, errors.New("invalid normalization form("+form+")"))
 }
 
-func getS3ImageBinary(cfg *aws.Config, bucket, key string) (io.Reader, error) {
+func getS3ImageBinary(cfg *aws.Config, bucket, key string, b []byte) (io.Reader, error) {
 	downloader := s3manager.NewDownloader(s3.NewFromConfig(*cfg))
-	buf := s3manager.NewWriteAtBuffer([]byte{})
+	buf := s3manager.NewWriteAtBuffer(b)
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),

--- a/lib/content/s3/s3_test.go
+++ b/lib/content/s3/s3_test.go
@@ -24,7 +24,7 @@ func initialize() {
 	testKey = "test/test.jpg"
 }
 
-func mockS3GetFunc(config *aws.Config, bucket, key string) (io.Reader, error) {
+func mockS3GetFunc(config *aws.Config, bucket, key string, b []byte) (io.Reader, error) {
 	if config == nil {
 		return strings.NewReader("failed"), errors.New("config is empty")
 	} else if config.Region != testRegion {
@@ -54,11 +54,11 @@ func newTestContent() *content.Content {
 func TestGetImageBinary(t *testing.T) {
 	initialize()
 	c := newTestContent()
-	if _, err := GetImageBinary(c); err != nil {
+	if _, err := GetImageBinary(c, []byte{}); err != nil {
 		t.Log("normal pattern.")
 		t.Fatal(err)
 	}
-	if _, err := GetImageBinary(nil); err == nil {
+	if _, err := GetImageBinary(nil, []byte{}); err == nil {
 		t.Log("abnormal pattern.")
 		t.Fatal("err is nil.")
 	}

--- a/lib/content/s3/s3_test.go
+++ b/lib/content/s3/s3_test.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -24,7 +25,7 @@ func initialize() {
 	testKey = "test/test.jpg"
 }
 
-func mockS3GetFunc(config *aws.Config, bucket, key string, b []byte) (io.Reader, error) {
+func mockS3GetFunc(config *aws.Config, bucket, key string, b *bytes.Buffer) (io.Reader, error) {
 	if config == nil {
 		return strings.NewReader("failed"), errors.New("config is empty")
 	} else if config.Region != testRegion {
@@ -54,11 +55,11 @@ func newTestContent() *content.Content {
 func TestGetImageBinary(t *testing.T) {
 	initialize()
 	c := newTestContent()
-	if _, err := GetImageBinary(c, []byte{}); err != nil {
+	if _, err := GetImageBinary(c, new(bytes.Buffer)); err != nil {
 		t.Log("normal pattern.")
 		t.Fatal(err)
 	}
-	if _, err := GetImageBinary(nil, []byte{}); err == nil {
+	if _, err := GetImageBinary(nil, new(bytes.Buffer)); err == nil {
 		t.Log("abnormal pattern.")
 		t.Fatal("err is nil.")
 	}

--- a/lib/content/source.go
+++ b/lib/content/source.go
@@ -10,14 +10,14 @@ import (
 
 type source struct {
 	name           string
-	getImageBinary func(*Content) (io.Reader, error)
+	getImageBinary func(*Content, []byte) (io.Reader, error)
 }
 
 var sources []source
 
 // RegisterContentType registers an content type for use by GetContent.
 // Name is the name of the content type, like "web" or "s3".
-func RegisterContentType(name string, getImageBinary func(*Content) (io.Reader, error)) {
+func RegisterContentType(name string, getImageBinary func(*Content, []byte) (io.Reader, error)) {
 	sources = append(sources, source{
 		name,
 		getImageBinary,
@@ -34,12 +34,12 @@ func sniff(c *Content) source {
 	return source{}
 }
 
-func GetImageBinary(c *Content) (io.Reader, error) {
+func GetImageBinary(c *Content, b []byte) (io.Reader, error) {
 	f := sniff(c)
 	if f.getImageBinary == nil {
 		return nil, imgproxyerr.New(imgproxyerr.WARNING, errors.New("unknown content type"))
 	}
-	m, err := f.getImageBinary(c)
+	m, err := f.getImageBinary(c, b)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/content/source.go
+++ b/lib/content/source.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"bytes"
 	"errors"
 
 	"io"
@@ -10,14 +11,14 @@ import (
 
 type source struct {
 	name           string
-	getImageBinary func(*Content, []byte) (io.Reader, error)
+	getImageBinary func(*Content, *bytes.Buffer) (io.Reader, error)
 }
 
 var sources []source
 
 // RegisterContentType registers an content type for use by GetContent.
 // Name is the name of the content type, like "web" or "s3".
-func RegisterContentType(name string, getImageBinary func(*Content, []byte) (io.Reader, error)) {
+func RegisterContentType(name string, getImageBinary func(*Content, *bytes.Buffer) (io.Reader, error)) {
 	sources = append(sources, source{
 		name,
 		getImageBinary,
@@ -34,7 +35,7 @@ func sniff(c *Content) source {
 	return source{}
 }
 
-func GetImageBinary(c *Content, b []byte) (io.Reader, error) {
+func GetImageBinary(c *Content, b *bytes.Buffer) (io.Reader, error) {
 	f := sniff(c)
 	if f.getImageBinary == nil {
 		return nil, imgproxyerr.New(imgproxyerr.WARNING, errors.New("unknown content type"))

--- a/lib/content/web/web.go
+++ b/lib/content/web/web.go
@@ -22,14 +22,14 @@ type RealWebClient struct {
 }
 
 type WebClient interface {
-	Get(string, []byte) (io.Reader, error)
+	Get(string, *bytes.Buffer) (io.Reader, error)
 }
 
 type Client struct {
 	Http WebClient
 }
 
-func (r *RealWebClient) Get(url string, b []byte) (io.Reader, error) {
+func (r *RealWebClient) Get(url string, buffer *bytes.Buffer) (io.Reader, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, imgproxyerr.New(imgproxyerr.ERROR, err)
@@ -46,7 +46,6 @@ func (r *RealWebClient) Get(url string, b []byte) (io.Reader, error) {
 		return nil, imgproxyerr.New(imgproxyerr.WARNING, fmt.Errorf("received error status code(%d)", resp.StatusCode))
 	}
 
-	buffer := bytes.NewBuffer(b)
 	if _, err := io.Copy(buffer, resp.Body); err != nil {
 		return nil, err
 	}
@@ -63,7 +62,7 @@ func isErrorCode(status int) bool {
 	}
 }
 
-func GetImageBinary(c *content.Content, b []byte) (io.Reader, error) {
+func GetImageBinary(c *content.Content, b *bytes.Buffer) (io.Reader, error) {
 	return httpClient.Http.Get(c.SourcePlace, b)
 }
 

--- a/lib/content/web/web.go
+++ b/lib/content/web/web.go
@@ -9,7 +9,7 @@ import (
 	"io"
 
 	"github.com/livesense-inc/fanlin/lib/content"
-	"github.com/livesense-inc/fanlin/lib/error"
+	imgproxyerr "github.com/livesense-inc/fanlin/lib/error"
 )
 
 var ua = fmt.Sprintf("Mozilla/5.0 (fanlin; arch: %s; OS: %s; Go version: %s) Go language Client/1.1 (KHTML, like Gecko) Version/1.0 fanlin", runtime.GOARCH, runtime.GOOS, runtime.Version())
@@ -22,14 +22,14 @@ type RealWebClient struct {
 }
 
 type WebClient interface {
-	Get(string) (io.Reader, error)
+	Get(string, []byte) (io.Reader, error)
 }
 
 type Client struct {
 	Http WebClient
 }
 
-func (r *RealWebClient) Get(url string) (io.Reader, error) {
+func (r *RealWebClient) Get(url string, b []byte) (io.Reader, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, imgproxyerr.New(imgproxyerr.ERROR, err)
@@ -46,7 +46,7 @@ func (r *RealWebClient) Get(url string) (io.Reader, error) {
 		return nil, imgproxyerr.New(imgproxyerr.WARNING, fmt.Errorf("received error status code(%d)", resp.StatusCode))
 	}
 
-	buffer := new(bytes.Buffer)
+	buffer := bytes.NewBuffer(b)
 	if _, err := io.Copy(buffer, resp.Body); err != nil {
 		return nil, err
 	}
@@ -63,8 +63,8 @@ func isErrorCode(status int) bool {
 	}
 }
 
-func GetImageBinary(c *content.Content) (io.Reader, error) {
-	return httpClient.Http.Get(c.SourcePlace)
+func GetImageBinary(c *content.Content, b []byte) (io.Reader, error) {
+	return httpClient.Http.Get(c.SourcePlace, b)
 }
 
 func setHttpClient(c Client) {

--- a/lib/content/web/web_test.go
+++ b/lib/content/web/web_test.go
@@ -25,7 +25,7 @@ func getTestClient() *Client {
 	return c
 }
 
-func (mwc *MockWebClient) Get(url string) (io.Reader, error) {
+func (mwc *MockWebClient) Get(url string, b []byte) (io.Reader, error) {
 	if url != targetURL {
 		return nil, errors.New("not match url. url: " + url + ", targetURL: " + targetURL)
 	}
@@ -52,13 +52,13 @@ func TestGetImageBinary(t *testing.T) {
 	c := &content.Content{
 		SourcePlace: targetURL,
 	}
-	result, err := GetImageBinary(c)
+	result, err := GetImageBinary(c, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	bin, err := io.ReadAll(result)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	if string(bin) != "It works!" {
 		t.Fatal(string(bin))

--- a/lib/content/web/web_test.go
+++ b/lib/content/web/web_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -25,7 +26,7 @@ func getTestClient() *Client {
 	return c
 }
 
-func (mwc *MockWebClient) Get(url string, b []byte) (io.Reader, error) {
+func (mwc *MockWebClient) Get(url string, b *bytes.Buffer) (io.Reader, error) {
 	if url != targetURL {
 		return nil, errors.New("not match url. url: " + url + ", targetURL: " + targetURL)
 	}
@@ -52,7 +53,7 @@ func TestGetImageBinary(t *testing.T) {
 	c := &content.Content{
 		SourcePlace: targetURL,
 	}
-	result, err := GetImageBinary(c, []byte{})
+	result, err := GetImageBinary(c, new(bytes.Buffer))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -190,7 +190,7 @@ func EncodeAVIF(buf io.Writer, img *image.Image, q int) error {
 }
 
 // DecodeImage is return image.Image
-func DecodeImage(r io.Reader, b []byte) (*Image, error) {
+func DecodeImage(r io.Reader, b *bytes.Buffer) (*Image, error) {
 	img, format, err := decode(r, b)
 	return &Image{img: img, format: format}, imgproxyerr.New(imgproxyerr.WARNING, err)
 }
@@ -311,7 +311,7 @@ func (i *Image) GetFormat() string {
 	return i.format
 }
 
-func Set404Image(buf io.Writer, tmpBuf []byte, path string, w uint, h uint, c color.Color, maxW uint, maxH uint) error {
+func Set404Image(buf io.Writer, tmpBuf *bytes.Buffer, path string, w uint, h uint, c color.Color, maxW uint, maxH uint) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return imgproxyerr.New(imgproxyerr.ERROR, err)
@@ -363,8 +363,7 @@ func readOrientation(r io.Reader) (o int, err error) {
 	return
 }
 
-func decode(r io.Reader, b []byte) (d image.Image, format string, err error) {
-	buf := bytes.NewBuffer(b)
+func decode(r io.Reader, buf *bytes.Buffer) (d image.Image, format string, err error) {
 	tee := io.TeeReader(r, buf)
 
 	s, format, err := image.Decode(tee)

--- a/lib/image/image_test.go
+++ b/lib/image/image_test.go
@@ -33,7 +33,7 @@ var ResizeAndFillImage = resizeAndFillImage
 var Crop = crop
 
 func TestEncodeJpeg(t *testing.T) {
-	img, _ := DecodeImage(jpegBin, []byte{})
+	img, _ := DecodeImage(jpegBin, new(bytes.Buffer))
 	jpegBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "jpeg" {
 		t.Fatalf("format is %v, expected jpeg", format)
@@ -46,7 +46,7 @@ func TestEncodeJpeg(t *testing.T) {
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin, []byte{})
+	img, _ = DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 	err = EncodeJpeg(&b, img.GetImg(), 50)
 	if err == nil {
@@ -57,7 +57,7 @@ func TestEncodeJpeg(t *testing.T) {
 
 func BenchmarkEncodeJpeg(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		img, _ := DecodeImage(jpegBin, []byte{})
+		img, _ := DecodeImage(jpegBin, new(bytes.Buffer))
 		jpegBin.Seek(0, 0)
 		if format := img.GetFormat(); format != "jpeg" {
 			log.Fatalf("format is %v, expected jpeg", format)
@@ -70,7 +70,7 @@ func BenchmarkEncodeJpeg(b *testing.B) {
 		}
 		b.Reset()
 
-		img, _ = DecodeImage(confBin, []byte{})
+		img, _ = DecodeImage(confBin, new(bytes.Buffer))
 		confBin.Seek(0, 0)
 		err = EncodeJpeg(&b, img.GetImg(), 50)
 		if err == nil {
@@ -81,7 +81,7 @@ func BenchmarkEncodeJpeg(b *testing.B) {
 }
 
 func TestEncodePNG(t *testing.T) {
-	img, _ := DecodeImage(pngBin, []byte{})
+	img, _ := DecodeImage(pngBin, new(bytes.Buffer))
 	pngBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "png" {
 		t.Fatalf("format is %v, expected png", format)
@@ -94,7 +94,7 @@ func TestEncodePNG(t *testing.T) {
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin, []byte{})
+	img, _ = DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 	err = EncodePNG(&b, img.GetImg(), 50)
 	if err == nil {
@@ -104,7 +104,7 @@ func TestEncodePNG(t *testing.T) {
 }
 
 func TestEncodeGIF(t *testing.T) {
-	img, _ := DecodeImage(gifBin, []byte{})
+	img, _ := DecodeImage(gifBin, new(bytes.Buffer))
 	gifBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "gif" {
 		t.Fatalf("format is %v, expected png", format)
@@ -117,7 +117,7 @@ func TestEncodeGIF(t *testing.T) {
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin, []byte{})
+	img, _ = DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 	err = EncodeGIF(&b, img.GetImg(), 50)
 	if err == nil {
@@ -128,7 +128,7 @@ func TestEncodeGIF(t *testing.T) {
 
 func TestEncodeWebP(t *testing.T) {
 	// Lossless
-	img, _ := DecodeImage(webpLosslessBin, []byte{})
+	img, _ := DecodeImage(webpLosslessBin, new(bytes.Buffer))
 	webpLosslessBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
@@ -142,7 +142,7 @@ func TestEncodeWebP(t *testing.T) {
 	b.Reset()
 
 	// Lossy
-	img, _ = DecodeImage(webpLossyBin, []byte{})
+	img, _ = DecodeImage(webpLossyBin, new(bytes.Buffer))
 	webpLossyBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
@@ -155,7 +155,7 @@ func TestEncodeWebP(t *testing.T) {
 	b.Reset()
 
 	// error
-	img, _ = DecodeImage(confBin, []byte{})
+	img, _ = DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 	err = EncodeWebP(&b, img.GetImg(), 50, true)
 	if err == nil {
@@ -167,14 +167,14 @@ func TestEncodeWebP(t *testing.T) {
 func TestEncodeAVIF(t *testing.T) {
 	var b bytes.Buffer
 
-	img, _ := DecodeImage(pngBin, []byte{})
+	img, _ := DecodeImage(pngBin, new(bytes.Buffer))
 	pngBin.Seek(0, 0)
 	if err := EncodeAVIF(&b, img.GetImg(), 50); err != nil {
 		t.Fatal(err)
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin, []byte{})
+	img, _ = DecodeImage(confBin, new(bytes.Buffer))
 	pngBin.Seek(0, 0)
 	if err := EncodeAVIF(&b, img.GetImg(), 50); err == nil {
 		t.Fatal("err is nil")
@@ -183,7 +183,7 @@ func TestEncodeAVIF(t *testing.T) {
 }
 
 func TestDecodeImage(t *testing.T) {
-	img, err := DecodeImage(jpegBin, []byte{})
+	img, err := DecodeImage(jpegBin, new(bytes.Buffer))
 	jpegBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -193,7 +193,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(bmpBin, []byte{})
+	img, err = DecodeImage(bmpBin, new(bytes.Buffer))
 	bmpBin.Seek(0, 0)
 	if err != nil {
 		t.Fatalf("err is not nil. : %v", err)
@@ -202,7 +202,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("img.%v", img)
 	}
 
-	img, err = DecodeImage(pngBin, []byte{})
+	img, err = DecodeImage(pngBin, new(bytes.Buffer))
 	pngBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -212,7 +212,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(gifBin, []byte{})
+	img, err = DecodeImage(gifBin, new(bytes.Buffer))
 	gifBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -222,7 +222,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(webpLosslessBin, []byte{})
+	img, err = DecodeImage(webpLosslessBin, new(bytes.Buffer))
 	webpLosslessBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -232,7 +232,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(webpLossyBin, []byte{})
+	img, err = DecodeImage(webpLossyBin, new(bytes.Buffer))
 	webpLossyBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -242,7 +242,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(confBin, []byte{})
+	img, err = DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 	if err == nil {
 		t.Log(err)
@@ -255,7 +255,7 @@ func TestDecodeImage(t *testing.T) {
 }
 
 func TestResizeImage(t *testing.T) {
-	img, _ := DecodeImage(confBin, []byte{})
+	img, _ := DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 
 	resizeImg := ResizeImage(*img.GetImg(), 100, 100, 10000, 10000)
@@ -263,7 +263,7 @@ func TestResizeImage(t *testing.T) {
 		t.Fatalf("value is not nil.")
 	}
 
-	img, _ = DecodeImage(jpegBin, []byte{})
+	img, _ = DecodeImage(jpegBin, new(bytes.Buffer))
 	jpegBin.Seek(0, 0)
 	ii := *img.GetImg()
 	jpegRect := ii.Bounds()
@@ -326,7 +326,7 @@ func TestResizeAndFillImage(t *testing.T) {
 		B: 0xff,
 		A: 0xff,
 	}
-	img, _ := DecodeImage(confBin, []byte{})
+	img, _ := DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 
 	fillImg := ResizeAndFillImage(*img.GetImg(), 100, 100, c, 10000, 10000)
@@ -334,7 +334,7 @@ func TestResizeAndFillImage(t *testing.T) {
 		t.Fatalf("value is not nil.")
 	}
 
-	img, _ = DecodeImage(pngBin, []byte{})
+	img, _ = DecodeImage(pngBin, new(bytes.Buffer))
 	pngBin.Seek(0, 0)
 
 	fillImg = ResizeAndFillImage(*img.GetImg(), 100, 100, c, 10000, 10000)
@@ -405,7 +405,7 @@ func TestResizeAndFillImage(t *testing.T) {
 }
 
 func TestCrop(t *testing.T) {
-	img, _ := DecodeImage(confBin, []byte{})
+	img, _ := DecodeImage(confBin, new(bytes.Buffer))
 	confBin.Seek(0, 0)
 
 	cropImg := Crop(*img.GetImg(), 100, 100)
@@ -413,7 +413,7 @@ func TestCrop(t *testing.T) {
 		t.Fatalf("value is not nil.")
 	}
 
-	img, _ = DecodeImage(pngBin, []byte{})
+	img, _ = DecodeImage(pngBin, new(bytes.Buffer))
 	pngBin.Seek(0, 0)
 
 	cropImg = Crop(*img.GetImg(), 100, 100)

--- a/lib/image/image_test.go
+++ b/lib/image/image_test.go
@@ -33,7 +33,7 @@ var ResizeAndFillImage = resizeAndFillImage
 var Crop = crop
 
 func TestEncodeJpeg(t *testing.T) {
-	img, _ := DecodeImage(jpegBin)
+	img, _ := DecodeImage(jpegBin, []byte{})
 	jpegBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "jpeg" {
 		t.Fatalf("format is %v, expected jpeg", format)
@@ -46,7 +46,7 @@ func TestEncodeJpeg(t *testing.T) {
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
+	img, _ = DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 	err = EncodeJpeg(&b, img.GetImg(), 50)
 	if err == nil {
@@ -57,7 +57,7 @@ func TestEncodeJpeg(t *testing.T) {
 
 func BenchmarkEncodeJpeg(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		img, _ := DecodeImage(jpegBin)
+		img, _ := DecodeImage(jpegBin, []byte{})
 		jpegBin.Seek(0, 0)
 		if format := img.GetFormat(); format != "jpeg" {
 			log.Fatalf("format is %v, expected jpeg", format)
@@ -70,7 +70,7 @@ func BenchmarkEncodeJpeg(b *testing.B) {
 		}
 		b.Reset()
 
-		img, _ = DecodeImage(confBin)
+		img, _ = DecodeImage(confBin, []byte{})
 		confBin.Seek(0, 0)
 		err = EncodeJpeg(&b, img.GetImg(), 50)
 		if err == nil {
@@ -81,7 +81,7 @@ func BenchmarkEncodeJpeg(b *testing.B) {
 }
 
 func TestEncodePNG(t *testing.T) {
-	img, _ := DecodeImage(pngBin)
+	img, _ := DecodeImage(pngBin, []byte{})
 	pngBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "png" {
 		t.Fatalf("format is %v, expected png", format)
@@ -94,7 +94,7 @@ func TestEncodePNG(t *testing.T) {
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
+	img, _ = DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 	err = EncodePNG(&b, img.GetImg(), 50)
 	if err == nil {
@@ -104,7 +104,7 @@ func TestEncodePNG(t *testing.T) {
 }
 
 func TestEncodeGIF(t *testing.T) {
-	img, _ := DecodeImage(gifBin)
+	img, _ := DecodeImage(gifBin, []byte{})
 	gifBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "gif" {
 		t.Fatalf("format is %v, expected png", format)
@@ -117,7 +117,7 @@ func TestEncodeGIF(t *testing.T) {
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
+	img, _ = DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 	err = EncodeGIF(&b, img.GetImg(), 50)
 	if err == nil {
@@ -128,7 +128,7 @@ func TestEncodeGIF(t *testing.T) {
 
 func TestEncodeWebP(t *testing.T) {
 	// Lossless
-	img, _ := DecodeImage(webpLosslessBin)
+	img, _ := DecodeImage(webpLosslessBin, []byte{})
 	webpLosslessBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
@@ -142,7 +142,7 @@ func TestEncodeWebP(t *testing.T) {
 	b.Reset()
 
 	// Lossy
-	img, _ = DecodeImage(webpLossyBin)
+	img, _ = DecodeImage(webpLossyBin, []byte{})
 	webpLossyBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
@@ -155,7 +155,7 @@ func TestEncodeWebP(t *testing.T) {
 	b.Reset()
 
 	// error
-	img, _ = DecodeImage(confBin)
+	img, _ = DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 	err = EncodeWebP(&b, img.GetImg(), 50, true)
 	if err == nil {
@@ -167,14 +167,14 @@ func TestEncodeWebP(t *testing.T) {
 func TestEncodeAVIF(t *testing.T) {
 	var b bytes.Buffer
 
-	img, _ := DecodeImage(pngBin)
+	img, _ := DecodeImage(pngBin, []byte{})
 	pngBin.Seek(0, 0)
 	if err := EncodeAVIF(&b, img.GetImg(), 50); err != nil {
 		t.Fatal(err)
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
+	img, _ = DecodeImage(confBin, []byte{})
 	pngBin.Seek(0, 0)
 	if err := EncodeAVIF(&b, img.GetImg(), 50); err == nil {
 		t.Fatal("err is nil")
@@ -183,7 +183,7 @@ func TestEncodeAVIF(t *testing.T) {
 }
 
 func TestDecodeImage(t *testing.T) {
-	img, err := DecodeImage(jpegBin)
+	img, err := DecodeImage(jpegBin, []byte{})
 	jpegBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -193,7 +193,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(bmpBin)
+	img, err = DecodeImage(bmpBin, []byte{})
 	bmpBin.Seek(0, 0)
 	if err != nil {
 		t.Fatalf("err is not nil. : %v", err)
@@ -202,7 +202,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("img.%v", img)
 	}
 
-	img, err = DecodeImage(pngBin)
+	img, err = DecodeImage(pngBin, []byte{})
 	pngBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -212,7 +212,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(gifBin)
+	img, err = DecodeImage(gifBin, []byte{})
 	gifBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -222,7 +222,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(webpLosslessBin)
+	img, err = DecodeImage(webpLosslessBin, []byte{})
 	webpLosslessBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -232,7 +232,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(webpLossyBin)
+	img, err = DecodeImage(webpLossyBin, []byte{})
 	webpLossyBin.Seek(0, 0)
 	if err != nil {
 		t.Log(err)
@@ -242,7 +242,7 @@ func TestDecodeImage(t *testing.T) {
 		t.Fatalf("can not decode.")
 	}
 
-	img, err = DecodeImage(confBin)
+	img, err = DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 	if err == nil {
 		t.Log(err)
@@ -255,7 +255,7 @@ func TestDecodeImage(t *testing.T) {
 }
 
 func TestResizeImage(t *testing.T) {
-	img, _ := DecodeImage(confBin)
+	img, _ := DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 
 	resizeImg := ResizeImage(*img.GetImg(), 100, 100, 10000, 10000)
@@ -263,7 +263,7 @@ func TestResizeImage(t *testing.T) {
 		t.Fatalf("value is not nil.")
 	}
 
-	img, _ = DecodeImage(jpegBin)
+	img, _ = DecodeImage(jpegBin, []byte{})
 	jpegBin.Seek(0, 0)
 	ii := *img.GetImg()
 	jpegRect := ii.Bounds()
@@ -326,7 +326,7 @@ func TestResizeAndFillImage(t *testing.T) {
 		B: 0xff,
 		A: 0xff,
 	}
-	img, _ := DecodeImage(confBin)
+	img, _ := DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 
 	fillImg := ResizeAndFillImage(*img.GetImg(), 100, 100, c, 10000, 10000)
@@ -334,7 +334,7 @@ func TestResizeAndFillImage(t *testing.T) {
 		t.Fatalf("value is not nil.")
 	}
 
-	img, _ = DecodeImage(pngBin)
+	img, _ = DecodeImage(pngBin, []byte{})
 	pngBin.Seek(0, 0)
 
 	fillImg = ResizeAndFillImage(*img.GetImg(), 100, 100, c, 10000, 10000)
@@ -405,7 +405,7 @@ func TestResizeAndFillImage(t *testing.T) {
 }
 
 func TestCrop(t *testing.T) {
-	img, _ := DecodeImage(confBin)
+	img, _ := DecodeImage(confBin, []byte{})
 	confBin.Seek(0, 0)
 
 	cropImg := Crop(*img.GetImg(), 100, 100)
@@ -413,7 +413,7 @@ func TestCrop(t *testing.T) {
 		t.Fatalf("value is not nil.")
 	}
 
-	img, _ = DecodeImage(pngBin)
+	img, _ = DecodeImage(pngBin, []byte{})
 	pngBin.Seek(0, 0)
 
 	cropImg = Crop(*img.GetImg(), 100, 100)


### PR DESCRIPTION
## Summery
* Get rid of all unwieldy handlings with panic to be able to use defer
* Use [sync.Pool](https://pkg.go.dev/sync#Pool) for [bytes.Buffer](https://pkg.go.dev/bytes#Buffer) to lessen the load of the GC
* Use [s3.Client](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.GetObject) instead of [s3manager.Downloader](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/feature/s3/manager#Downloader) to be able to use [bytes.Buffer](https://pkg.go.dev/bytes#Buffer)
  * There's still room for consideration. Downloader is concurrent.

## Benchmark
`B/op` was a bit decreased.

### Before
```
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkMainHandler-4   	read configure. : /home/runner/work/fanlin/fanlin/lib/test/test_conf9.json
      16	  66068110 ns/op	13052543 B/op	 1573239 allocs/op
```

### After
```
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkMainHandler-4   	read configure. : /home/runner/work/fanlin/fanlin/lib/test/test_conf9.json
      18	  64630002 ns/op	11019228 B/op	 1573223 allocs/op
```

## Profiling
`bytes.growSlice` and `bytes.(*Buffer).grow` were a bit decreased.

### Before
```
Showing top 10 nodes out of 45
      flat  flat%   sum%        cum   cum%
      74MB 33.93% 33.93%       74MB 33.93%  image.(*YCbCr).At
   68.50MB 31.41% 65.34%   142.50MB 65.34%  github.com/BurntSushi/graphics-go/graphics/interp.bilinearGeneral
   34.04MB 15.61% 80.95%    34.04MB 15.61%  bytes.growSlice
      24MB 11.00% 91.96%       24MB 11.00%  image.NewRGBA
   13.52MB  6.20% 98.16%    13.52MB  6.20%  image.NewYCbCr
    2.01MB  0.92% 99.08%     2.01MB  0.92%  io.ReadAll
         0     0% 99.08%    17.94MB  8.22%  bufio.(*Reader).Read
         0     0% 99.08%    16.11MB  7.39%  bytes.(*Buffer).ReadFrom
         0     0% 99.08%    17.94MB  8.22%  bytes.(*Buffer).Write
         0     0% 99.08%    34.04MB 15.61%  bytes.(*Buffer).grow
```

### After
```
Showing top 10 nodes out of 31
      flat  flat%   sum%        cum   cum%
   76.50MB 37.75% 37.75%   148.50MB 73.28%  github.com/BurntSushi/graphics-go/graphics/interp.bilinearGeneral
      72MB 35.53% 73.28%       72MB 35.53%  image.(*YCbCr).At
   32.66MB 16.11% 89.39%    32.66MB 16.11%  image.NewRGBA
   16.41MB  8.10% 97.49%    16.41MB  8.10%  image.NewYCbCr
    1.51MB  0.74% 98.23%     1.51MB  0.74%  github.com/rwcarlsen/goexif/exif.newAppSec
    1.07MB  0.53% 98.76%     1.07MB  0.53%  bytes.growSlice
    0.51MB  0.25% 99.01%    16.92MB  8.35%  image/jpeg.Decode
         0     0% 99.01%     1.07MB  0.53%  bytes.(*Buffer).ReadFrom
         0     0% 99.01%     1.07MB  0.53%  bytes.(*Buffer).grow
         0     0% 99.01%   148.50MB 73.28%  github.com/BurntSushi/graphics-go/graphics.Affine.Transform
```