### PR TITLE
Use boilerplates instead of using panic at error handlings

### DIFF
--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -21,7 +21,7 @@ func (c *Conf) UseMLCMYKConverter() bool {
 	}
 	r, ok := b.(bool)
 	if !ok {
-		panic("'use_ml_cmyk_converter' parameter is incorrect")
+		return false
 	}
 	return r
 }
@@ -33,7 +33,7 @@ func (c *Conf) MLCMYKConverterNetworkFilePath() string {
 	}
 	s, ok := i.(string)
 	if !ok {
-		panic("'ml_cmyk_converter_network_file_path' parameter is incorrect")
+		return ""
 	}
 	return s
 }
@@ -45,7 +45,7 @@ func (c *Conf) UseServerTiming() bool {
 	}
 	r, ok := b.(bool)
 	if !ok {
-		panic("'use_server_timing' parameter is incorrect")
+		return false
 	}
 	return r
 }
@@ -57,7 +57,7 @@ func (c *Conf) EnableMetricsEndpoint() bool {
 	}
 	r, ok := b.(bool)
 	if !ok {
-		panic("'enable_metrics_endpoint' parameter is incorrect")
+		return false
 	}
 	return r
 }
@@ -69,7 +69,7 @@ func (c *Conf) MaxClients() int {
 	}
 	n, ok := b.(float64)
 	if !ok {
-		panic("'max_clients' parameter is incorrect")
+		return 50
 	}
 	return int(n)
 }
@@ -145,7 +145,7 @@ func (c *Conf) BackendRequestTimeout() time.Duration {
 
 	d, err := time.ParseDuration(t)
 	if err != nil {
-		panic(err)
+		return 10 * time.Second
 	}
 	return d
 }

--- a/lib/content/web/web_test.go
+++ b/lib/content/web/web_test.go
@@ -58,7 +58,7 @@ func TestGetImageBinary(t *testing.T) {
 	}
 	bin, err := io.ReadAll(result)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	if string(bin) != "It works!" {
 		t.Fatal(string(bin))

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -198,7 +198,6 @@ func fallback(
 			writeDebugLog(err, conf.DebugLogPath())
 			errLogger.Error(err)
 		}
-
 	} else {
 		writeDebugLog(err, conf.DebugLogPath())
 		log.Println(err)


### PR DESCRIPTION
I'll close this pull request if there is a rational reason to use `panic` at error handlings.