### PR TITLE
Prevent printing verbose and too much information at initialization

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -47,21 +47,21 @@ var (
 )
 
 func showVersion() {
-	log.Print()
+	fmt.Println()
 	if buildVersion != "" {
-		log.Print("build version: ", buildVersion)
+		fmt.Println("build version: ", buildVersion)
 	} else {
-		log.Print("build version: ", buildHash)
+		fmt.Println("build version: ", buildHash)
 	}
-	log.Print("build date: ", buildDate)
-	log.Print("GO version: ", goversion)
+	fmt.Println("build date: ", buildDate)
+	fmt.Println("GO version: ", goversion)
 }
 
 func main() {
 	conf := func() *configure.Conf {
 		for _, confName := range confList {
 			if conf, path := configure.NewConfigure(confName); conf != nil {
-				log.Print("read configure. :", path)
+				fmt.Println("read configure. :", path)
 				return conf
 			}
 		}

--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	configure "github.com/livesense-inc/fanlin/lib/conf"
@@ -60,8 +61,12 @@ func showVersion() {
 func main() {
 	conf := func() *configure.Conf {
 		for _, confName := range confList {
-			if conf, path := configure.NewConfigure(confName); conf != nil {
-				fmt.Println("read configure. :", path)
+			if conf := configure.NewConfigure(confName); conf != nil {
+				if p, err := filepath.Abs(confName); err != nil {
+					fmt.Println("read configure. :", confName)
+				} else {
+					fmt.Println("read configure. :", p)
+				}
 				return conf
 			}
 		}

--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -47,28 +47,28 @@ var (
 )
 
 func showVersion() {
-	fmt.Println()
+	log.Print()
 	if buildVersion != "" {
-		fmt.Println("build version: ", buildVersion)
+		log.Print("build version: ", buildVersion)
 	} else {
-		fmt.Println("build version: ", buildHash)
+		log.Print("build version: ", buildHash)
 	}
-	fmt.Println("build date: ", buildDate)
-	fmt.Println("GO version: ", goversion)
+	log.Print("build date: ", buildDate)
+	log.Print("GO version: ", goversion)
 }
 
 func main() {
 	conf := func() *configure.Conf {
 		for _, confName := range confList {
-			conf := configure.NewConfigure(confName)
-			if conf != nil {
+			if conf, path := configure.NewConfigure(confName); conf != nil {
+				log.Print("read configure. :", path)
 				return conf
 			}
 		}
 		return nil
 	}()
 	if conf == nil {
-		log.Fatalln("Can not read configure.")
+		log.Fatal("Can not read configure.")
 	}
 
 	notFoundImagePath := flag.String("nfi", conf.NotFoundImagePath(), "not found image path")
@@ -98,7 +98,7 @@ func main() {
 	}
 
 	if *debug {
-		fmt.Println(conf)
+		log.Print(conf)
 	}
 
 	http.DefaultClient.Timeout = conf.BackendRequestTimeout()

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -220,7 +220,7 @@ func (c *Conf) includeConfigure(mainConfPath string, pathList []string) {
 		if abs == "" {
 			continue
 		}
-		include, _ := NewConfigure(abs)
+		include := NewConfigure(abs)
 		if include == nil {
 			continue
 		}
@@ -231,19 +231,18 @@ func (c *Conf) includeConfigure(mainConfPath string, pathList []string) {
 	}
 }
 
-func NewConfigure(confPath string) (*Conf, string) {
+func NewConfigure(confPath string) *Conf {
 	var conf map[string]interface{}
 	bin, err := os.ReadFile(confPath)
 	if err != nil {
-		return nil, ""
+		return nil
 	}
 	err = json.Unmarshal(bin, &conf)
 	if err != nil {
-		return nil, ""
+		return nil
 	}
-	p, err := filepath.Abs(confPath)
 	if err != nil {
-		return nil, ""
+		return nil
 	}
 	c := Conf{
 		c: conf,
@@ -252,5 +251,5 @@ func NewConfigure(confPath string) (*Conf, string) {
 	c.includeConfigure(confPath, includes)
 
 	delete(c.c, "include")
-	return &c, p
+	return &c
 }

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -241,9 +241,6 @@ func NewConfigure(confPath string) *Conf {
 	if err != nil {
 		return nil
 	}
-	if err != nil {
-		return nil
-	}
 	c := Conf{
 		c: conf,
 	}

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -220,7 +220,7 @@ func (c *Conf) includeConfigure(mainConfPath string, pathList []string) {
 		if abs == "" {
 			continue
 		}
-		include := NewConfigure(abs)
+		include, _ := NewConfigure(abs)
 		if include == nil {
 			continue
 		}
@@ -231,20 +231,20 @@ func (c *Conf) includeConfigure(mainConfPath string, pathList []string) {
 	}
 }
 
-func NewConfigure(confPath string) *Conf {
+func NewConfigure(confPath string) (*Conf, string) {
 	var conf map[string]interface{}
 	bin, err := os.ReadFile(confPath)
 	if err != nil {
-		fmt.Println(err)
-		return nil
+		return nil, ""
 	}
 	err = json.Unmarshal(bin, &conf)
 	if err != nil {
-		fmt.Println(err)
-		return nil
+		return nil, ""
 	}
-	p, _ := filepath.Abs(confPath)
-	fmt.Println("read configure. :", p)
+	p, err := filepath.Abs(confPath)
+	if err != nil {
+		return nil, ""
+	}
 	c := Conf{
 		c: conf,
 	}
@@ -252,5 +252,5 @@ func NewConfigure(confPath string) *Conf {
 	c.includeConfigure(confPath, includes)
 
 	delete(c.c, "include")
-	return &c
+	return &c, p
 }

--- a/lib/conf/conf_test.go
+++ b/lib/conf/conf_test.go
@@ -1,30 +1,29 @@
 package configure
 
 import (
-	"fmt"
 	"testing"
 )
 
 var testConfig = "../test/test_conf.json"
 
 func TestReadConfigure(t *testing.T) {
-	conf := NewConfigure(testConfig)
+	conf, _ := NewConfigure(testConfig)
 	func() {
-		fmt.Println("test conf struct all.")
+		t.Log("test conf struct all.")
 		if conf == nil {
 			t.Fatalf("conf is nil.")
 		}
 	}()
 
 	func() {
-		fmt.Println("port setting test.")
+		t.Log("port setting test.")
 		if conf.Port() != 8080 {
 			t.Fatalf("port is not equal 8080, value is \"%v\"", conf.Port())
 		}
 	}()
 
 	func() {
-		fmt.Println("max size test")
+		t.Log("max size test")
 		w, h := conf.MaxSize()
 		if w != 5000 {
 			t.Fatalf("value is %v", w)
@@ -35,7 +34,7 @@ func TestReadConfigure(t *testing.T) {
 	}()
 
 	func() {
-		fmt.Println("use_server_timing test")
+		t.Log("use_server_timing test")
 		ok := conf.UseServerTiming()
 		if !ok {
 			t.Fatalf("value is %v", ok)
@@ -43,7 +42,7 @@ func TestReadConfigure(t *testing.T) {
 	}()
 
 	func() {
-		fmt.Println("enable_metrics_endpoint test")
+		t.Log("enable_metrics_endpoint test")
 		ok := conf.EnableMetricsEndpoint()
 		if !ok {
 			t.Fatalf("value is %v", ok)
@@ -51,7 +50,7 @@ func TestReadConfigure(t *testing.T) {
 	}()
 
 	func() {
-		fmt.Println("max_clients test")
+		t.Log("max_clients test")
 		n := conf.MaxClients()
 		if n != 50 {
 			t.Fatalf("value is %d", n)

--- a/lib/conf/conf_test.go
+++ b/lib/conf/conf_test.go
@@ -7,7 +7,7 @@ import (
 var testConfig = "../test/test_conf.json"
 
 func TestReadConfigure(t *testing.T) {
-	conf, _ := NewConfigure(testConfig)
+	conf := NewConfigure(testConfig)
 	func() {
 		t.Log("test conf struct all.")
 		if conf == nil {

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -30,7 +30,7 @@ func TestMakeMetricsHandler(t *testing.T) {
 }
 
 func BenchmarkMainHandler(b *testing.B) {
-	c := configure.NewConfigure("../test/test_conf9.json")
+	c, _ := configure.NewConfigure("../test/test_conf9.json")
 	if c == nil {
 		b.Fatal("Failed to build config")
 	}

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -30,7 +30,7 @@ func TestMakeMetricsHandler(t *testing.T) {
 }
 
 func BenchmarkMainHandler(b *testing.B) {
-	c, _ := configure.NewConfigure("../test/test_conf9.json")
+	c := configure.NewConfigure("../test/test_conf9.json")
 	if c == nil {
 		b.Fatal("Failed to build config")
 	}


### PR DESCRIPTION
## Before

```
$ make run
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -trimpath -tags timetzdata -o cmd/fanlin/server cmd/fanlin/main.go
open /etc/fanlin.json: no such file or directory
open /etc/fanlin.cnf: no such file or directory
open /etc/fanlin.conf: no such file or directory
open /usr/local/etc/fanlin.json: no such file or directory
open /usr/local/etc/fanlin.cnf: no such file or directory
open /usr/local/etc/fanlin.conf: no such file or directory
open /usr/local/fanlin/fanlin.json: no such file or directory
open /usr/local/fanlin.json: no such file or directory
open /usr/local/fanlin.conf: no such file or directory
read configure. : /home/kasuga/vcs/fanlin/fanlin.json
```

## After

```
$ make run
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -trimpath -tags timetzdata -o cmd/fanlin/server cmd/fanlin/main.go
read configure. : /home/kasuga/vcs/fanlin/fanlin.json
```