### PR TITLE
Add another way for matching against path routing

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -104,6 +104,8 @@ func main() {
 	http.DefaultClient.Timeout = conf.BackendRequestTimeout()
 	runtime.GOMAXPROCS(conf.MaxProcess())
 
+	handler.Initialize(conf)
+
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		handler.MainHandler(w, r, conf, loggers)
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.54
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.74.1
 	github.com/chai2010/webp v1.1.1
+	github.com/hashicorp/go-immutable-radix v1.3.1
 	github.com/ieee0824/libcmyk v0.0.0-20171222081915-8cf9151a408c
 	github.com/ieee0824/logrus-formatter v1.0.0
 	github.com/mitchellh/go-server-timing v1.0.1
@@ -42,6 +43,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.0 // indirect
 	github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5 // indirect
+	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,12 @@ github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5/go.mod h1:xEhNfoBDX1hz
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
+github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
+github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ieee0824/libcmyk v0.0.0-20171222081915-8cf9151a408c h1:lZIOmqDjhSYVjRKP2uDatozIISiwqf2SKdJiY9guH/8=
 github.com/ieee0824/libcmyk v0.0.0-20171222081915-8cf9151a408c/go.mod h1:vJVtPiJ4YFtcMk8WkYjRnhqve5VTNuURZ2qmD0yRdyE=
 github.com/ieee0824/logrus-formatter v1.0.0 h1:xGeQsIDW3Cap0t2be6xyT4CEu4QTTNXxRGv8+foASM8=

--- a/lib/content/content.go
+++ b/lib/content/content.go
@@ -65,7 +65,7 @@ func makeRouter(conf *configure.Conf) *iradix.Tree {
 				prefix = fmt.Sprintf("/%s", prefix)
 			}
 			m := convertInterfaceToMap(meta)
-			router, _, _ = router.Insert([]byte(alias), provider{alias, m})
+			router, _, _ = router.Insert([]byte(prefix), provider{alias, m})
 		}
 	}
 	return router

--- a/lib/content/content_test.go
+++ b/lib/content/content_test.go
@@ -53,7 +53,7 @@ func BenchmarkGetContentFromSortedList(b *testing.B) {
 	useRouter = false
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if got := GetContent("/foo", conf); got == nil {
+		if got := GetContent("/j/image.jpg", conf); got == nil {
 			b.Fatalf("no content")
 		}
 	}
@@ -65,7 +65,9 @@ func BenchmarkGetContentByRouter(b *testing.B) {
 	useRouter = true
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if got := GetContent("/foobarbazgquuuuuu", conf); got == nil {
+		if got := GetContent("/j/image.jpg", conf); got == nil {
+			b.Fatalf("no content")
+		} else if got.SourcePlace != "/tmp/j/image.jpg" {
 			b.Fatalf("no content")
 		}
 	}

--- a/lib/content/content_test.go
+++ b/lib/content/content_test.go
@@ -48,7 +48,7 @@ func TestGetContent(t *testing.T) {
 }
 
 func BenchmarkGetContentFromSortedList(b *testing.B) {
-	conf := configure.NewConfigure("../test/test_conf8.json")
+	conf := configure.NewConfigure("../test/test_conf7.json")
 	SetUpProviders(conf)
 	useRouter = false
 	b.ResetTimer()
@@ -60,7 +60,7 @@ func BenchmarkGetContentFromSortedList(b *testing.B) {
 }
 
 func BenchmarkGetContentByRouter(b *testing.B) {
-	conf := configure.NewConfigure("../test/test_conf8.json")
+	conf := configure.NewConfigure("../test/test_conf7.json")
 	SetUpProviders(conf)
 	useRouter = true
 	b.ResetTimer()

--- a/lib/content/content_test.go
+++ b/lib/content/content_test.go
@@ -1,0 +1,72 @@
+package content
+
+import (
+	"testing"
+
+	configure "github.com/livesense-inc/fanlin/lib/conf"
+)
+
+func TestGetContent(t *testing.T) {
+	conf := configure.NewConfigure("../test/test_conf8.json")
+	SetUpProviders(conf)
+	cases := []struct {
+		urlPath         string
+		wantSourcePlace string
+	}{
+		{"/image.jpg", "/tmp/image.jpg"},
+		{"/foo/image.jpg", "/tmp/foo/image.jpg"},
+		{"/foobar/image.jpg", "/tmp/foobar/image.jpg"},
+		{"/foobarbaz/image.jpg", "/tmp/foobarbaz/image.jpg"},
+		{"/foobarbazgqu/image.jpg", "/tmp/foobarbazgqu/image.jpg"},
+		{"/foobarbazgquu/image.jpg", "/tmp/foobarbazgquu/image.jpg"},
+		{"/foobarbazgquuu/image.jpg", "/tmp/foobarbazgquuu/image.jpg"},
+		{"/foobarbazgquuuu/image.jpg", "/tmp/foobarbazgquuuu/image.jpg"},
+		{"/foobarbazgquuuuu/image.jpg", "/tmp/foobarbazgquuuuu/image.jpg"},
+		{"/foobarbazgquuuuuu/image.jpg", "/tmp/foobarbazgquuuuuu/image.jpg"},
+	}
+
+	for _, flag := range []bool{false, true} {
+		useRouter = flag
+		for n, c := range cases {
+			got := GetContent(c.urlPath, conf)
+			if got == nil {
+				t.Errorf("useRouter: %v, case: %d, no content", useRouter, n)
+				continue
+			}
+			if got.SourcePlace != c.wantSourcePlace {
+				t.Errorf(
+					"useRouter: %v, case: %d, want=%s, got=%s",
+					useRouter,
+					n,
+					c.wantSourcePlace,
+					got.SourcePlace,
+				)
+			}
+		}
+	}
+
+}
+
+func BenchmarkGetContentFromSortedList(b *testing.B) {
+	conf := configure.NewConfigure("../test/test_conf8.json")
+	SetUpProviders(conf)
+	useRouter = false
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := GetContent("/foo", conf); got == nil {
+			b.Fatalf("no content")
+		}
+	}
+}
+
+func BenchmarkGetContentByRouter(b *testing.B) {
+	conf := configure.NewConfigure("../test/test_conf8.json")
+	SetUpProviders(conf)
+	useRouter = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := GetContent("/foobarbazgquuuuuu", conf); got == nil {
+			b.Fatalf("no content")
+		}
+	}
+}

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -207,3 +207,7 @@ func MakeMetricsHandler(conf *configure.Conf, logger *log.Logger) http.Handler {
 		),
 	)
 }
+
+func Initialize(conf *configure.Conf) {
+	content.SetUpProviders(conf)
+}

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -34,6 +34,7 @@ func BenchmarkMainHandler(b *testing.B) {
 	if c == nil {
 		b.Fatal("Failed to build config")
 	}
+	Initialize(c)
 
 	w := helper.NewNullResponseWriter()
 	r := &http.Request{

--- a/lib/test/test_conf7.json
+++ b/lib/test/test_conf7.json
@@ -1,0 +1,80 @@
+{
+    "port": 8080,
+    "max_width": 1000,
+    "max_height": 1000,
+    "404_img_path": "../../img/404.png",
+    "access_log_path": "/dev/null",
+    "error_log_path": "/dev/null",
+    "providers": [
+        {
+            "/a" : {
+                "type" : "local",
+                "src" : "/tmp/a",
+                "priority": 0
+            }
+        },
+        {
+            "/b" : {
+                "type" : "local",
+                "src" : "/tmp/b",
+                "priority": 1
+            }
+        },
+        {
+            "/c" : {
+                "type" : "local",
+                "src" : "/tmp/c",
+                "priority": 2
+            }
+        },
+        {
+            "/d" : {
+                "type" : "local",
+                "src" : "/tmp/d",
+                "priority": 3
+            }
+        },
+        {
+            "/e" : {
+                "type" : "local",
+                "src" : "/tmp/e",
+                "priority": 4
+            }
+        },
+        {
+            "/f" : {
+                "type" : "local",
+                "src" : "/tmp/f",
+                "priority": 5
+            }
+        },
+        {
+            "/g" : {
+                "type" : "local",
+                "src" : "/tmp/g",
+                "priority": 6
+            }
+        },
+        {
+            "/h" : {
+                "type" : "local",
+                "src" : "/tmp/h",
+                "priority": 7
+            }
+        },
+        {
+            "/i" : {
+                "type" : "local",
+                "src" : "/tmp/i",
+                "priority": 8
+            }
+        },
+        {
+            "/j" : {
+                "type" : "local",
+                "src" : "/tmp/j",
+                "priority": 9
+            }
+        }
+    ]
+}

--- a/lib/test/test_conf8.json
+++ b/lib/test/test_conf8.json
@@ -7,6 +7,13 @@
     "error_log_path": "/dev/null",
     "providers": [
         {
+            "/" : {
+                "type" : "local",
+                "src" : "/tmp",
+                "priority": 0
+            }
+        },
+        {
             "/foo" : {
                 "type" : "local",
                 "src" : "/tmp/foo",
@@ -67,76 +74,6 @@
                 "type" : "local",
                 "src" : "/tmp/foobarbazgquuuuuu",
                 "priority": 1
-            }
-        },
-        {
-            "/" : {
-                "type" : "local",
-                "src" : "/tmp",
-                "priority": 0
-            }
-        },
-        {
-            "/dir1" : {
-                "type" : "local",
-                "src" : "/tmp/dir1",
-                "priority": 0
-            }
-        },
-        {
-            "/dir2" : {
-                "type" : "local",
-                "src" : "/tmp/dir2",
-                "priority": 0
-            }
-        },
-        {
-            "/dir3" : {
-                "type" : "local",
-                "src" : "/tmp/dir3",
-                "priority": 0
-            }
-        },
-        {
-            "/dir4" : {
-                "type" : "local",
-                "src" : "/tmp/dir4",
-                "priority": 0
-            }
-        },
-        {
-            "/dir5" : {
-                "type" : "local",
-                "src" : "/tmp/dir5",
-                "priority": 0
-            }
-        },
-        {
-            "/dir6" : {
-                "type" : "local",
-                "src" : "/tmp/dir6",
-                "priority": 0
-            }
-        },
-        {
-            "/dir7" : {
-                "type" : "local",
-                "src" : "/tmp/dir7",
-                "priority": 0
-            }
-        },
-        {
-            "/dir8" : {
-                "type" : "local",
-                "src" : "/tmp/dir8",
-                "priority": 0
-            }
-        },
-        {
-            "/dir9" : {
-                "type" : "local",
-                "src" : "/tmp/dir9",
-                "priority": 0
             }
         }
     ]

--- a/lib/test/test_conf8.json
+++ b/lib/test/test_conf8.json
@@ -1,0 +1,143 @@
+{
+    "port": 8080,
+    "max_width": 1000,
+    "max_height": 1000,
+    "404_img_path": "../../img/404.png",
+    "access_log_path": "/dev/null",
+    "error_log_path": "/dev/null",
+    "providers": [
+        {
+            "/foo" : {
+                "type" : "local",
+                "src" : "/tmp/foo",
+                "priority": 9
+            }
+        },
+        {
+            "/foobar" : {
+                "type" : "local",
+                "src" : "/tmp/foobar",
+                "priority": 8
+            }
+        },
+        {
+            "/foobarbaz" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbaz",
+                "priority": 7
+            }
+        },
+        {
+            "/foobarbazgqu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgqu",
+                "priority": 6
+            }
+        },
+        {
+            "/foobarbazgquu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquu",
+                "priority": 5
+            }
+        },
+        {
+            "/foobarbazgquuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuu",
+                "priority": 4
+            }
+        },
+        {
+            "/foobarbazgquuuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuuu",
+                "priority": 3
+            }
+        },
+        {
+            "/foobarbazgquuuuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuuuu",
+                "priority": 2
+            }
+        },
+        {
+            "/foobarbazgquuuuuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuuuuu",
+                "priority": 1
+            }
+        },
+        {
+            "/" : {
+                "type" : "local",
+                "src" : "/tmp",
+                "priority": 0
+            }
+        },
+        {
+            "/dir1" : {
+                "type" : "local",
+                "src" : "/tmp/dir1",
+                "priority": 0
+            }
+        },
+        {
+            "/dir2" : {
+                "type" : "local",
+                "src" : "/tmp/dir2",
+                "priority": 0
+            }
+        },
+        {
+            "/dir3" : {
+                "type" : "local",
+                "src" : "/tmp/dir3",
+                "priority": 0
+            }
+        },
+        {
+            "/dir4" : {
+                "type" : "local",
+                "src" : "/tmp/dir4",
+                "priority": 0
+            }
+        },
+        {
+            "/dir5" : {
+                "type" : "local",
+                "src" : "/tmp/dir5",
+                "priority": 0
+            }
+        },
+        {
+            "/dir6" : {
+                "type" : "local",
+                "src" : "/tmp/dir6",
+                "priority": 0
+            }
+        },
+        {
+            "/dir7" : {
+                "type" : "local",
+                "src" : "/tmp/dir7",
+                "priority": 0
+            }
+        },
+        {
+            "/dir8" : {
+                "type" : "local",
+                "src" : "/tmp/dir8",
+                "priority": 0
+            }
+        },
+        {
+            "/dir9" : {
+                "type" : "local",
+                "src" : "/tmp/dir9",
+                "priority": 0
+            }
+        }
+    ]
+}


### PR DESCRIPTION
https://github.com/hashicorp/go-immutable-radix

```
goos: linux
goarch: amd64
pkg: github.com/livesense-inc/fanlin/lib/content
cpu: AMD EPYC 7763 64-Core Processor
```

```
BenchmarkGetContentFromSortedList-4
 3927085	       306.0 ns/op	     392 B/op	       4 allocs/op
```

```
BenchmarkGetContentByRouter-4
 2563122	       476.9 ns/op	     432 B/op	       5 allocs/op
```

It seems that naive loop search is faster than radix tree in our use case.