### PR TITLE
Fix a race condition

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -104,6 +104,8 @@ func main() {
 	http.DefaultClient.Timeout = conf.BackendRequestTimeout()
 	runtime.GOMAXPROCS(conf.MaxProcess())
 
+	handler.Prepare(conf)
+
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		handler.MainHandler(w, r, conf, loggers)
 	}

--- a/lib/content/content.go
+++ b/lib/content/content.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/livesense-inc/fanlin/lib/conf"
+	configure "github.com/livesense-inc/fanlin/lib/conf"
 )
 
 type Content struct {
@@ -93,16 +93,17 @@ func convertInterfaceToMap(i interface{}) map[string]interface{} {
 	return map[string]interface{}(nil)
 }
 
-func GetContent(urlPath string, conf *configure.Conf) *Content {
-	if urlPath == "" {
-		return nil
-	}
+func SetUpProviders(conf *configure.Conf) {
 	if conf == nil {
-		return nil
+		return
 	}
 
-	if providers == nil {
-		providers = getProviders(conf)
+	providers = getProviders(conf)
+}
+
+func GetContent(urlPath string, _conf *configure.Conf) *Content {
+	if urlPath == "" {
+		return nil
 	}
 
 	return getContent(urlPath, providers)

--- a/lib/content/content_test.go
+++ b/lib/content/content_test.go
@@ -1,0 +1,47 @@
+package content
+
+import (
+	"fmt"
+	"testing"
+
+	configure "github.com/livesense-inc/fanlin/lib/conf"
+)
+
+func TestGetContent(t *testing.T) {
+	t.Parallel()
+	conf := configure.NewConfigure("../test/test_conf8.json")
+	if conf == nil {
+		t.Fatal("failed to read conf")
+	}
+	SetUpProviders(conf)
+	cases := []struct {
+		urlPath         string
+		wantSourcePlace string
+	}{
+		{"/image.jpg", "/tmp/image.jpg"},
+		{"/foo/image.jpg", "/tmp/foo/image.jpg"},
+		{"/foobar/image.jpg", "/tmp/foobar/image.jpg"},
+		{"/foobarbaz/image.jpg", "/tmp/foobarbaz/image.jpg"},
+		{"/foobarbazgqu/image.jpg", "/tmp/foobarbazgqu/image.jpg"},
+		{"/foobarbazgquu/image.jpg", "/tmp/foobarbazgquu/image.jpg"},
+		{"/foobarbazgquuu/image.jpg", "/tmp/foobarbazgquuu/image.jpg"},
+		{"/foobarbazgquuuu/image.jpg", "/tmp/foobarbazgquuuu/image.jpg"},
+		{"/foobarbazgquuuuu/image.jpg", "/tmp/foobarbazgquuuuu/image.jpg"},
+		{"/foobarbazgquuuuuu/image.jpg", "/tmp/foobarbazgquuuuuu/image.jpg"},
+	}
+	for n, c := range cases {
+		n := n
+		c := c
+		t.Run(fmt.Sprintf("case-%d", n), func(t *testing.T) {
+			t.Parallel()
+			got := GetContent(c.urlPath, conf)
+			if got == nil {
+				t.Errorf("no content")
+				return
+			}
+			if got.SourcePlace != c.wantSourcePlace {
+				t.Errorf("want=%s, got=%s", c.wantSourcePlace, got.SourcePlace)
+			}
+		})
+	}
+}

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -207,3 +207,7 @@ func MakeMetricsHandler(conf *configure.Conf, logger *log.Logger) http.Handler {
 		),
 	)
 }
+
+func Prepare(conf *configure.Conf) {
+	content.SetUpProviders(conf)
+}

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -34,6 +34,7 @@ func BenchmarkMainHandler(b *testing.B) {
 	if c == nil {
 		b.Fatal("Failed to build config")
 	}
+	Prepare(c)
 
 	w := helper.NewNullResponseWriter()
 	r := &http.Request{

--- a/lib/test/test_conf8.json
+++ b/lib/test/test_conf8.json
@@ -1,0 +1,80 @@
+{
+    "port": 8080,
+    "max_width": 1000,
+    "max_height": 1000,
+    "404_img_path": "../../img/404.png",
+    "access_log_path": "/dev/null",
+    "error_log_path": "/dev/null",
+    "providers": [
+        {
+            "/" : {
+                "type" : "local",
+                "src" : "/tmp",
+                "priority": 0
+            }
+        },
+        {
+            "/foo" : {
+                "type" : "local",
+                "src" : "/tmp/foo",
+                "priority": 9
+            }
+        },
+        {
+            "/foobar" : {
+                "type" : "local",
+                "src" : "/tmp/foobar",
+                "priority": 8
+            }
+        },
+        {
+            "/foobarbaz" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbaz",
+                "priority": 7
+            }
+        },
+        {
+            "/foobarbazgqu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgqu",
+                "priority": 6
+            }
+        },
+        {
+            "/foobarbazgquu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquu",
+                "priority": 5
+            }
+        },
+        {
+            "/foobarbazgquuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuu",
+                "priority": 4
+            }
+        },
+        {
+            "/foobarbazgquuuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuuu",
+                "priority": 3
+            }
+        },
+        {
+            "/foobarbazgquuuuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuuuu",
+                "priority": 2
+            }
+        },
+        {
+            "/foobarbazgquuuuuu" : {
+                "type" : "local",
+                "src" : "/tmp/foobarbazgquuuuuu",
+                "priority": 1
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The `providers` global variable in the content package is written once and read by the main handler which is called concurrently by each requests. Thus there is a race condition. It can be reproduced with a parallel unit test. So I think it should be kept data initialized in advance.