### PR TITLE
Update readme file

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@ Amazon S3と外部HTTPサーバー上の画像をリアルタイムで加工す�
 * macOS
 
 ### Go Versions
-* go 1.19.x
+* `go.mod` ファイル参照
 
 ## 対応画像フォーマット
 * JPEG
@@ -35,7 +35,6 @@ $ sudo apt install libaom-dev
 ```
 
 ## Linux用にクロスコンパイルする
-### go1.19
 ```
 $ GOOS=linux GOARCH=amd64 go build github.com/livesense-inc/fanlin/cmd/fanlin
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 English | [日本語](README.ja.md)
 
 ## abstract
-fanlin is image proxy server in native Go language.
+fanlin is image proxy server written in Go language.
 
 ## Support
 ### OS
@@ -13,7 +13,7 @@ fanlin is image proxy server in native Go language.
 * macOS
 
 ### Go Versions
-* go 1.19.x
+* Please see `go.mod`
 
 ### Image Format
 * JPEG
@@ -30,7 +30,6 @@ $ sudo apt install libaom-dev
 ```
 
 ## Cross compile for amd64 Linux
-### go 1.19
 ```
 $ GOOS=linux GOARCH=amd64 go build github.com/livesense-inc/fanlin/cmd/fanlin
 ```


### PR DESCRIPTION
* Remove explicit Go version from README.md, mention `go.mod` instead
* Remove wording of "native Go" because it's no longer true
  * e.g. WebP and AVIF formats support needs C libraries