### PR TITLE
Publish container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,14 @@
 .git
 .github
+*.log
+*.out
+*.test
 *.txt
 *.md
 *.json
 *.yaml
 __debug_bin
 result.bin
+/img
+/cmd/fanlin/server
+/lib/test

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+*.txt
+*.md
+*.json
+*.yaml
+__debug_bin
+result.bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,6 @@ jobs:
     if: github.repository == 'livesense-inc/fanlin'
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    concurrency: ${{ github.workflow }}
     permissions:
       packages: write
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
   push:
     tags:
       - "v*"
+defaults:
+  run:
+    shell: bash
 concurrency: ${{ github.workflow }}
 jobs:
   executable-files:
@@ -45,3 +48,42 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  container:
+    name: Container
+    if: github.repository == 'livesense-inc/fanlin'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    concurrency: ${{ github.workflow }}
+    permissions:
+      packages: write
+    env:
+      IMAGE_NAME: fanlin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: docker build . -t $IMAGE_NAME
+
+      - name: Version
+        id: version
+        run: |
+          version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && version=$(echo $version | sed -e 's/^v//')
+          [ "$version" == "main" ] && version=latest
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Login
+        run: >
+          echo "${{ secrets.GITHUB_TOKEN }}"
+          | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Tag
+        id: tag
+        run: |
+          tag=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:${{ steps.version.outputs.value }}
+          docker tag $IMAGE_NAME $tag
+          echo "value=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Push
+        run: docker push ${{ steps.tag.outputs.value }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && version=$(echo $version | sed -e 's/^v//')
-          [ "$version" == "main" ] && version=latest
+          [ "$version" == "master" ] && version=latest
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - name: Login

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ vendor/
 /*.out
 /*.test
 __debug_bin
+result.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1-bookworm AS builder
+RUN set -eux; \
+  apt-get update -y; \
+  apt-get install -y --no-install-recommends ca-certificates build-essential make libaom-dev
+WORKDIR /usr/src/app
+COPY . .
+RUN make build
+
+# https://github.com/GoogleContainerTools/distroless
+# https://console.cloud.google.com/gcr/images/distroless/GLOBAL
+FROM gcr.io/distroless/cc-debian12:nonroot-amd64
+COPY --from=builder /lib/x86_64-linux-gnu/libaom.so.* /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libm.so.* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/src/app/cmd/fanlin/server /usr/local/bin/fanlin
+ENTRYPOINT ["/usr/local/bin/fanlin"]

--- a/cmd/fanlin/sample-conf-container.json
+++ b/cmd/fanlin/sample-conf-container.json
@@ -1,0 +1,19 @@
+{
+    "port": 3000,
+    "max_width": 3000,
+    "max_height": 3000,
+    "404_img_path": "/var/lib/fanlin/img/404.png",
+    "access_log_path": "/dev/stdout",
+    "error_log_path": "/dev/stderr",
+    "use_server_timing": true,
+    "enable_metrics_endpoint": true,
+    "max_clients": 50,
+    "providers": [
+        {
+            "/" : {
+                "type" : "local",
+                "src" : "/var/lib/fanlin/img"
+            }
+        }
+    ]
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,10 @@
+---
+services:
+  app:
+    build: .
+    image: fanlin
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./img:/var/lib/fanlin/img
+      - ./cmd/fanlin/sample-conf-container.json:/etc/fanlin.json


### PR DESCRIPTION
Since we supports WebP and AVIF formats, our build steps are a bit awkward. So I'd say that it would be better to publish the container image as a base image to the publish repository so that users don't need to bake their own images from scratch. And the container image size is approximately 50 MB.