### PR TITLE
Add a functionality for the testing of the S3 provider with MinIO on local and fix a bug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ result.bin
 /img
 /cmd/fanlin/server
 /lib/test
+/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ vendor/
 /*.test
 __debug_bin
 result.bin
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ MAKEFLAGS += --warn-undefined-variables
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 CGO_ENABLED ?= $(shell go env CGO_ENABLED)
+AWS_ENDPOINT_URL := http://127.0.0.1:4567
+AWS_REGION := ap-northeast-1
+AWS_CMD_ENV += AWS_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAA
+AWS_CMD_ENV += AWS_SECRET_ACCESS_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AWS_CMD_OPT += --endpoint-url=${AWS_ENDPOINT_URL}
+AWS_CMD_OPT += --region=${AWS_REGION}
+AWS_CMD := ${AWS_CMD_ENV} aws ${AWS_CMD_OPT}
+AWS_S3_BUCKET_NAME := local-test
 
 build: cmd/fanlin/server
 
@@ -39,5 +47,19 @@ prof:
 clean:
 	@unlink fanlin.json || true
 	@rm -f cmd/fanlin/server cmd/fanlin/fanlin.json
+
+create-s3-bucket:
+	@${AWS_CMD} s3api create-bucket \
+		--bucket=${AWS_S3_BUCKET_NAME} \
+		--create-bucket-configuration LocationConstraint=${AWS_REGION}
+
+clean-s3-bucket:
+	@${AWS_CMD} s3 rm s3://${AWS_S3_BUCKET_NAME} --include='*' --recursive
+
+list-s3-bucket:
+	@${AWS_CMD} s3 ls s3://${AWS_S3_BUCKET_NAME}/${FOLDER}
+
+copy-object:
+	@${AWS_CMD} s3 cp ${SRC} s3://${AWS_S3_BUCKET_NAME}/${DEST}
 
 .PHONY: build cmd/fanlin/server run test lint bench prof clean

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,22 @@
 ---
 services:
-  app:
-    build: .
-    image: fanlin
+  s3:
+    image: "minio/minio"
     ports:
-      - "3001:3000"
+      - "4567:9000"
+    environment:
+      MINIO_ROOT_USER: AAAAAAAAAAAAAAAAAAAA
+      MINIO_ROOT_PASSWORD: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
     volumes:
-      - ./img:/var/lib/fanlin/img
-      - ./cmd/fanlin/sample-conf-container.json:/etc/fanlin.json
+      - ./tmp/s3:/data
+    command:
+      - server
+      - /data
+# app:
+#   build: .
+#   image: fanlin
+#   ports:
+#     - "3001:3000"
+#   volumes:
+#     - ./img:/var/lib/fanlin/img
+#     - ./cmd/fanlin/sample-conf-container.json:/etc/fanlin.json

--- a/lib/content/s3/s3.go
+++ b/lib/content/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/url"
 
@@ -122,9 +123,9 @@ func getS3ImageBinary(cli *s3.Client, bucket, key string) (io.Reader, error) {
 	}
 	_, err := downloader.Download(context.TODO(), buf, input)
 	if err != nil {
-		return nil, imgproxyerr.New(imgproxyerr.WARNING, err)
+		return nil, imgproxyerr.New(imgproxyerr.WARNING, fmt.Errorf("bucket=%s, key=%s: %w", bucket, key, err))
 	}
-	return bytes.NewReader(buf.Bytes()), imgproxyerr.New(imgproxyerr.ERROR, err)
+	return bytes.NewReader(buf.Bytes()), nil
 }
 
 func init() {

--- a/lib/content/s3/s3.go
+++ b/lib/content/s3/s3.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -115,6 +116,9 @@ func NormalizePath(path string, form string) (string, error) {
 }
 
 func getS3ImageBinary(cli *s3.Client, bucket, key string) (io.Reader, error) {
+	if strings.HasPrefix(key, "/") {
+		key = strings.TrimPrefix(key, "/")
+	}
 	downloader := s3manager.NewDownloader(cli)
 	buf := s3manager.NewWriteAtBuffer([]byte{})
 	input := &s3.GetObjectInput{

--- a/lib/content/s3/s3.go
+++ b/lib/content/s3/s3.go
@@ -116,9 +116,7 @@ func NormalizePath(path string, form string) (string, error) {
 }
 
 func getS3ImageBinary(cli *s3.Client, bucket, key string) (io.Reader, error) {
-	if strings.HasPrefix(key, "/") {
-		key = strings.TrimPrefix(key, "/")
-	}
+	key = strings.TrimPrefix(key, "/")
 	downloader := s3manager.NewDownloader(cli)
 	buf := s3manager.NewWriteAtBuffer([]byte{})
 	input := &s3.GetObjectInput{

--- a/lib/content/s3/s3_test.go
+++ b/lib/content/s3/s3_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/livesense-inc/fanlin/lib/content"
 )
 
@@ -24,11 +24,9 @@ func initialize() {
 	testKey = "test/test.jpg"
 }
 
-func mockS3GetFunc(config *aws.Config, bucket, key string) (io.Reader, error) {
-	if config == nil {
-		return strings.NewReader("failed"), errors.New("config is empty")
-	} else if config.Region != testRegion {
-		return strings.NewReader("failed"), errors.New("Mismatch of the config region. region: " + config.Region + ", testRegion: " + testRegion)
+func mockS3GetFunc(client *s3.Client, bucket, key string) (io.Reader, error) {
+	if client == nil {
+		return strings.NewReader("failed"), errors.New("client is empty")
 	} else if bucket == "" {
 		return strings.NewReader("failed"), errors.New("bucket is empty")
 	} else if bucket != testBucket {


### PR DESCRIPTION
This pull request makes our AWS S3 client able to access local mock with [MinIO](https://github.com/minio/minio). And it fixes a bug related to a prefix in a object key.

Also, this is a bit off topic, but I have no idea yet how to improve current behavior which builds client every time per request. I think it needs breaking changes for config specification. The client is Goroutine safe.