### PR TITLE
Fix a bug related to server-timing header

### DIFF
--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -129,8 +129,8 @@ func MainHandler(
 
 	q := query.NewQueryFromGet(r)
 
-	m = timing.NewMetric("f_decode").Start()
-	img, err := decodeImage(buf, conf, q)
+	m = timing.NewMetric("f_process").Start()
+	img, err := processImage(buf, conf, q)
 	if err != nil {
 		fallback(
 			w, r, conf, loggers,
@@ -140,7 +140,6 @@ func MainHandler(
 	}
 	m.Stop()
 
-	m = timing.NewMetric("f_encode").Start()
 	if q.UseAVIF() {
 		w.Header().Set("Content-Type", "image/avif")
 	}
@@ -152,7 +151,6 @@ func MainHandler(
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "%s", "server error")
 	}
-	m.Stop()
 }
 
 func getImage(reqPath string, conf *configure.Conf) (io.Reader, error) {
@@ -163,7 +161,7 @@ func getImage(reqPath string, conf *configure.Conf) (io.Reader, error) {
 	return content.GetImageBinary(ctt)
 }
 
-func decodeImage(buf io.Reader, conf *configure.Conf, q *query.Query) (*imageprocessor.Image, error) {
+func processImage(buf io.Reader, conf *configure.Conf, q *query.Query) (*imageprocessor.Image, error) {
 	img, err := imageprocessor.DecodeImage(buf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request fixes two things as follows:

* Remove `f_encode` metrics from server timing
  * Because we directly write encode data into ResponseWriter, we are no longer able to measure the metrics before sending response body.
    * #65
    * The above modification is leading the following bug:
      * > write: broken pipe
      * > http: superfluous response.WriteHeader call from main.main.Middleware.func4.1.1 (middleware.go:55)
* Rename `f_decode` metrics with `f_process` and rename related method too
  * Because the function does decode and resizing.