### PR TITLE
Cache 404 image in memory on boot

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -113,7 +113,9 @@ func main() {
 	http.DefaultClient.Timeout = conf.BackendRequestTimeout()
 	runtime.GOMAXPROCS(conf.MaxProcess())
 
-	handler.Prepare(conf)
+	if err := handler.Prepare(conf); err != nil {
+		log.Fatal(err)
+	}
 
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		handler.MainHandler(w, r, conf, loggers)

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -31,7 +31,7 @@ func create404Page(w http.ResponseWriter, r *http.Request, conf *configure.Conf)
 
 	maxW, maxH := conf.MaxSize()
 	w.WriteHeader(404)
-	if err := imageprocessor.Set404Image(w, conf.NotFoundImagePath(), q.Bounds().W, q.Bounds().H, *q.FillColor(), maxW, maxH); err != nil {
+	if err := imageprocessor.Set404Image(w, content.GetNoContentImage(), q.Bounds().W, q.Bounds().H, *q.FillColor(), maxW, maxH); err != nil {
 		writeDebugLog(err, conf.DebugLogPath())
 		log.Println(err)
 		fmt.Fprintf(w, "%s", "404 Not found.")
@@ -249,6 +249,10 @@ func MakeMetricsHandler(conf *configure.Conf, logger *log.Logger) http.Handler {
 	)
 }
 
-func Prepare(conf *configure.Conf) {
+func Prepare(conf *configure.Conf) error {
 	content.SetUpProviders(conf)
+	if err := content.SetupNoContentImage(conf); err != nil {
+		return err
+	}
+	return nil
 }

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -11,7 +11,6 @@ import (
 	"image/png"
 	"io"
 	"math"
-	"os"
 	"sync"
 
 	"github.com/BurntSushi/graphics-go/graphics"
@@ -311,12 +310,8 @@ func (i *Image) GetFormat() string {
 	return i.format
 }
 
-func Set404Image(buf io.Writer, path string, w uint, h uint, c color.Color, maxW uint, maxH uint) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return imgproxyerr.New(imgproxyerr.ERROR, err)
-	}
-	img, err := DecodeImage(f)
+func Set404Image(buf io.Writer, data io.Reader, w uint, h uint, c color.Color, maxW uint, maxH uint) error {
+	img, err := DecodeImage(data)
 	if err != nil {
 		return imgproxyerr.New(imgproxyerr.ERROR, err)
 	}


### PR DESCRIPTION
If a content is not found, fanlin returns a fallback image. It is loaded from disk every single time. I'd say that it would be better to cache it before server started.