### PR TITLE
Add server-side timeout option

### DIFF
--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -150,10 +150,13 @@ func runServer(conf *configure.Conf) error {
 	}
 	defer listener.Close()
 
-	server := &http.Server{
-		ReadTimeout:  conf.ServerTimeout(),
-		WriteTimeout: conf.ServerTimeout(),
-		IdleTimeout:  conf.ServerIdleTimeout(),
+	server := &http.Server{}
+	if conf.ServerTimeout() > 0*time.Second {
+		server.ReadTimeout = conf.ServerTimeout()
+		server.WriteTimeout = conf.ServerTimeout()
+	}
+	if conf.ServerIdleTimeout() > 0*time.Second {
+		server.IdleTimeout = conf.ServerIdleTimeout()
 	}
 
 	c := make(chan os.Signal, 1)

--- a/cmd/fanlin/main.go
+++ b/cmd/fanlin/main.go
@@ -132,7 +132,7 @@ func main() {
 		http.HandleFunc("/metrics", metricsHandler.ServeHTTP)
 	}
 
-	if err := runServer(fmt.Sprintf(":%d", conf.Port()), conf.MaxClients()); err != nil {
+	if err := runServer(conf); err != nil {
 		log.Fatal(err)
 	}
 
@@ -140,17 +140,21 @@ func main() {
 	os.Exit(0)
 }
 
-func runServer(addr string, maxClients int) error {
-	listener, err := net.Listen("tcp", addr)
+func runServer(conf *configure.Conf) error {
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", conf.Port()))
 	if err != nil {
 		return err
 	}
-	if maxClients > 0 {
-		listener = netutil.LimitListener(listener, maxClients)
+	if conf.MaxClients() > 0 {
+		listener = netutil.LimitListener(listener, conf.MaxClients())
 	}
 	defer listener.Close()
 
-	server := &http.Server{}
+	server := &http.Server{
+		ReadTimeout:  conf.ServerTimeout(),
+		WriteTimeout: conf.ServerTimeout(),
+		IdleTimeout:  conf.ServerIdleTimeout(),
+	}
 
 	c := make(chan os.Signal, 1)
 	defer close(c)

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -153,17 +153,17 @@ func (c *Conf) BackendRequestTimeout() time.Duration {
 func (c *Conf) ServerTimeout() time.Duration {
 	tstr, ok := c.c["server_timeout"]
 	if !ok {
-		return 30 * time.Second
+		return 0 * time.Second
 	}
 
 	t, ok := tstr.(string)
 	if !ok {
-		return 30 * time.Second
+		return 0 * time.Second
 	}
 
 	d, err := time.ParseDuration(t)
 	if err != nil {
-		return 30 * time.Second
+		return 0 * time.Second
 	}
 	return d
 }
@@ -171,17 +171,17 @@ func (c *Conf) ServerTimeout() time.Duration {
 func (c *Conf) ServerIdleTimeout() time.Duration {
 	tstr, ok := c.c["server_idle_timeout"]
 	if !ok {
-		return 65 * time.Second
+		return 0 * time.Second
 	}
 
 	t, ok := tstr.(string)
 	if !ok {
-		return 65 * time.Second
+		return 0 * time.Second
 	}
 
 	d, err := time.ParseDuration(t)
 	if err != nil {
-		return 65 * time.Second
+		return 0 * time.Second
 	}
 	return d
 }

--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -150,6 +150,42 @@ func (c *Conf) BackendRequestTimeout() time.Duration {
 	return d
 }
 
+func (c *Conf) ServerTimeout() time.Duration {
+	tstr, ok := c.c["server_timeout"]
+	if !ok {
+		return 30 * time.Second
+	}
+
+	t, ok := tstr.(string)
+	if !ok {
+		return 30 * time.Second
+	}
+
+	d, err := time.ParseDuration(t)
+	if err != nil {
+		return 30 * time.Second
+	}
+	return d
+}
+
+func (c *Conf) ServerIdleTimeout() time.Duration {
+	tstr, ok := c.c["server_idle_timeout"]
+	if !ok {
+		return 65 * time.Second
+	}
+
+	t, ok := tstr.(string)
+	if !ok {
+		return 65 * time.Second
+	}
+
+	d, err := time.ParseDuration(t)
+	if err != nil {
+		return 65 * time.Second
+	}
+	return d
+}
+
 func (c *Conf) Port() int {
 	port := c.c["port"]
 	return convInterfaceToInt(port, 8080)

--- a/lib/conf/conf_test.go
+++ b/lib/conf/conf_test.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"testing"
+	"time"
 )
 
 var testConfig = "../test/test_conf.json"
@@ -53,6 +54,22 @@ func TestReadConfigure(t *testing.T) {
 		t.Log("max_clients test")
 		n := conf.MaxClients()
 		if n != 50 {
+			t.Fatalf("value is %d", n)
+		}
+	}()
+
+	func() {
+		t.Log("server_timeout test")
+		n := conf.ServerTimeout()
+		if n != 30*time.Second {
+			t.Fatalf("value is %d", n)
+		}
+	}()
+
+	func() {
+		t.Log("server_idle_timeout test")
+		n := conf.ServerIdleTimeout()
+		if n != 65*time.Second {
 			t.Fatalf("value is %d", n)
 		}
 	}()

--- a/lib/conf/conf_test.go
+++ b/lib/conf/conf_test.go
@@ -62,7 +62,7 @@ func TestReadConfigure(t *testing.T) {
 		t.Log("server_timeout test")
 		n := conf.ServerTimeout()
 		if n != 30*time.Second {
-			t.Fatalf("value is %d", n)
+			t.Errorf("value is %d", n)
 		}
 	}()
 
@@ -70,7 +70,7 @@ func TestReadConfigure(t *testing.T) {
 		t.Log("server_idle_timeout test")
 		n := conf.ServerIdleTimeout()
 		if n != 65*time.Second {
-			t.Fatalf("value is %d", n)
+			t.Errorf("value is %d", n)
 		}
 	}()
 }

--- a/lib/test/test_conf.json
+++ b/lib/test/test_conf.json
@@ -4,5 +4,7 @@
     "max_height": 5000,
     "use_server_timing": true,
     "enable_metrics_endpoint": true,
-    "max_clients": 50
+    "max_clients": 50,
+    "server_timeout": "30s",
+    "server_idle_timeout": "65s"
 }


### PR DESCRIPTION
I'd say that the timeout settings is nice-to-have for the consideration of performance or malicious attack. The behavior is as is if there is no specification in the setting. So this modification is backward compatible.

https://pkg.go.dev/net/http#Server