### PR TITLE
Revert a modification which writes encode data to the response directly, use buffer instead 

### DIFF
--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -31,14 +31,23 @@ func create404Page(w http.ResponseWriter, r *http.Request, conf *configure.Conf)
 	q := query.NewQueryFromGet(r)
 
 	maxW, maxH := conf.MaxSize()
-	w.WriteHeader(404)
-	if err := imageprocessor.Set404Image(w, content.GetNoContentImage(), q.Bounds().W, q.Bounds().H, *q.FillColor(), maxW, maxH); err != nil {
+	w.WriteHeader(http.StatusNotFound)
+	var b bytes.Buffer
+	if err := imageprocessor.Set404Image(
+		&b,
+		content.GetNoContentImage(),
+		q.Bounds().W,
+		q.Bounds().H,
+		*q.FillColor(),
+		maxW,
+		maxH,
+	); err != nil {
 		writeDebugLog(err, conf.DebugLogPath())
 		log.Println(err)
 		fmt.Fprintf(w, "%s", "404 Not found.")
+	} else {
+		_, _ = io.Copy(w, &b)
 	}
-
-	q = nil
 }
 
 func fallback(

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -140,16 +141,23 @@ func MainHandler(
 	}
 	m.Stop()
 
+	m = timing.NewMetric("f_encode").Start()
+	var b bytes.Buffer
+	if err := encodeImage(&b, img, q); err != nil {
+		fallback(
+			w, r, conf, loggers,
+			imgproxyerr.New(imgproxyerr.ERROR, fmt.Errorf("failed to encode image data: %w", err)),
+		)
+		return
+	}
+	m.Stop()
+
+	w.WriteHeader(http.StatusOK)
 	if q.UseAVIF() {
 		w.Header().Set("Content-Type", "image/avif")
 	}
-	if err := encodeImage(w, img, q); err != nil {
-		writeDebugLog(err, conf.DebugLogPath())
-		log.Println(err)
-
-		// The following writing to the headers will be ignored if the body was wrote with some bytes.
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "%s", "server error")
+	if _, err := io.Copy(w, &b); err != nil {
+		loggers["err"].Print("failed to write data to response:", err)
 	}
 }
 


### PR DESCRIPTION
I'm seeing an error in our staging environment as follows:

> write: broken pipe

```mermaid
graph TD
  client(Client)
  cdn(CDN)
  lb(Load Balancer)
  fanlin(Fanlin)
  client-->cdn
  cdn-->client
  cdn-->lb
  lb-->cdn
  lb-->fanlin
  fanlin--error-->lb
```

It seems that the error has not been solved by the following fix.

* #85

I'm not pretty sure why the error was occurred, but I suspect that the following fix was a bad idea.

* #65

So this pull request reverts the above modification.