### PR TITLE
Use gift, which makes us 3 times faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,17 @@ module github.com/livesense-inc/fanlin
 go 1.23.5
 
 require (
-	github.com/BurntSushi/graphics-go v0.0.0-20160129215708-b43f31a4a966
 	github.com/Kagami/go-avif v0.1.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/config v1.29.2
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.55
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.54
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.74.1
 	github.com/chai2010/webp v1.1.1
+	github.com/disintegration/gift v1.2.1
 	github.com/ieee0824/libcmyk v0.0.0-20171222081915-8cf9151a408c
 	github.com/ieee0824/logrus-formatter v1.0.0
 	github.com/mitchellh/go-server-timing v1.0.1
-	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/sirupsen/logrus v1.9.3
@@ -24,7 +24,6 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.55 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.25 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.29 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/BurntSushi/graphics-go v0.0.0-20160129215708-b43f31a4a966 h1:lTG4HQym5oPKjL7nGs+csTgiDna685ZXjxijkne828g=
-github.com/BurntSushi/graphics-go v0.0.0-20160129215708-b43f31a4a966/go.mod h1:Mid70uvE93zn9wgF92A/r5ixgnvX8Lh68fxp9KQBaI0=
 github.com/Kagami/go-avif v0.1.0 h1:8GHAGLxCdFfhpd4Zg8j1EqO7rtcQNenxIDerC/uu68w=
 github.com/Kagami/go-avif v0.1.0/go.mod h1:OPmPqzNdQq3+sXm0HqaUJQ9W/4k+Elbc3RSfJUemDKA=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -49,6 +47,8 @@ github.com/chai2010/webp v1.1.1/go.mod h1:0XVwvZWdjjdxpUEIf7b9g9VkHFnInUSYujwqTL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/disintegration/gift v1.2.1 h1:Y005a1X4Z7Uc+0gLpSAsKhWi4qLtsdEcMIbbdvdZ6pc=
+github.com/disintegration/gift v1.2.1/go.mod h1:Jh2i7f7Q2BM7Ezno3PhfezbR1xpUg9dUg3/RlKGr4HI=
 github.com/felixge/httpsnoop v1.0.0 h1:gh8fMGz0rlOv/1WmRZm7OgncIOTsAj21iNJot48omJQ=
 github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5 h1:yrv1uUvgXH/tEat+wdvJMRJ4g51GlIydtDpU9pFjaaI=
@@ -69,8 +69,6 @@ github.com/mitchellh/go-server-timing v1.0.1 h1:f00/aIe8T3MrnLhQHu3tSWvnwc5GV/p5
 github.com/mitchellh/go-server-timing v1.0.1/go.mod h1:Mo6GKi9FSLwWFAMn3bqVPWe20y5ri5QGQuO9D9MCOxk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
-github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -29,7 +29,7 @@ var devNull, _ = os.Open("/dev/null")
 
 func create404Page(w http.ResponseWriter, r *http.Request, conf *configure.Conf) {
 	q := query.NewQueryFromGet(r)
-	width, height := getWidthAndHeight(conf, q)
+	width, height := clampBounds(conf, q)
 	w.WriteHeader(http.StatusNotFound)
 	var b bytes.Buffer
 	if err := imageprocessor.Set404Image(
@@ -186,7 +186,7 @@ func processImage(buf io.Reader, conf *configure.Conf, q *query.Query) (*imagepr
 		}
 	}
 	img.ApplyOrientation()
-	w, h := getWidthAndHeight(conf, q)
+	w, h := clampBounds(conf, q)
 	if q.Crop() {
 		img.Crop(w, h)
 	} else {
@@ -196,7 +196,7 @@ func processImage(buf io.Reader, conf *configure.Conf, q *query.Query) (*imagepr
 	return img, nil
 }
 
-func getWidthAndHeight(conf *configure.Conf, q *query.Query) (w uint, h uint) {
+func clampBounds(conf *configure.Conf, q *query.Query) (w uint, h uint) {
 	mW, mX := conf.MaxSize()
 	b := q.Bounds()
 	w = min(b.W, mW)

--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -158,10 +158,10 @@ func MainHandler(
 	}
 	m.Stop()
 
-	w.WriteHeader(http.StatusOK)
 	if q.UseAVIF() {
 		w.Header().Set("Content-Type", "image/avif")
 	}
+	w.WriteHeader(http.StatusOK)
 	if _, err := io.Copy(w, &b); err != nil {
 		loggers["err"].Print("failed to write data to response:", err)
 	}

--- a/lib/handler/handler_test.go
+++ b/lib/handler/handler_test.go
@@ -48,6 +48,7 @@ func BenchmarkMainHandler(b *testing.B) {
 				q := url.Values{}
 				q.Set("w", "300")
 				q.Set("h", "200")
+				q.Set("rgb", "32,32,32")
 				return q.Encode()
 			}(),
 		},

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -13,33 +13,34 @@ import (
 	"math"
 	"sync"
 
-	"github.com/BurntSushi/graphics-go/graphics"
-	"github.com/BurntSushi/graphics-go/graphics/interp"
 	"github.com/Kagami/go-avif"
 	"github.com/chai2010/webp"
+	"github.com/disintegration/gift"
 	"github.com/ieee0824/libcmyk"
 	imgproxyerr "github.com/livesense-inc/fanlin/lib/error"
-	"github.com/nfnt/resize"
 	"github.com/rwcarlsen/goexif/exif"
 	_ "golang.org/x/image/bmp"
 )
 
-var affines map[int]graphics.Affine = map[int]graphics.Affine{
-	1: graphics.I,
-	2: graphics.I.Scale(-1, 1),
-	3: graphics.I.Scale(-1, -1),
-	4: graphics.I.Scale(1, -1),
-	5: graphics.I.Rotate(toRadian(90)).Scale(-1, 1),
-	6: graphics.I.Rotate(toRadian(90)),
-	7: graphics.I.Rotate(toRadian(-90)).Scale(-1, 1),
-	8: graphics.I.Rotate(toRadian(-90)),
+var affines = map[int]gift.Filter{
+	2: gift.FlipHorizontal(),
+	3: gift.Rotate180(),
+	4: gift.FlipVertical(),
+	5: gift.Transpose(),
+	6: gift.Rotate270(),
+	7: gift.Transverse(),
+	8: gift.Rotate90(),
 }
 
 var mlConverterCache = &sync.Map{}
 
 type Image struct {
-	img    image.Image
-	format string
+	img         image.Image
+	format      string
+	orientation int
+	fillColor   color.Color
+	outerBounds image.Rectangle
+	filter      *gift.GIFT
 }
 
 func (i *Image) ConvertColor(networkPath string) error {
@@ -188,118 +189,66 @@ func EncodeAVIF(buf io.Writer, img *image.Image, q int) error {
 	return nil
 }
 
-// DecodeImage is return image.Image
 func DecodeImage(r io.Reader) (*Image, error) {
-	img, format, err := decode(r)
-	return &Image{img: img, format: format}, imgproxyerr.New(imgproxyerr.WARNING, err)
+	img, format, orientation, err := decode(r)
+	wrapper := Image{
+		img:         img,
+		format:      format,
+		orientation: orientation,
+		outerBounds: img.Bounds(),
+		filter:      gift.New(),
+	}
+	return &wrapper, imgproxyerr.New(imgproxyerr.WARNING, err)
 }
 
-// アス比を維持した時の長さを取得する
-func keepAspect(img image.Image, w uint, h uint) (uint, uint) {
-	r := img.Bounds()
-	if int(w)*r.Max.Y < int(h)*r.Max.X {
-		return w, 0
+func (i *Image) Process() {
+	bounds := i.filter.Bounds(i.img.Bounds())
+	dest := image.NewRGBA(bounds)
+	i.filter.Draw(dest, i.img)
+
+	if dest.Bounds() == i.outerBounds || i.fillColor == nil {
+		i.img = dest
+		return
+	}
+
+	bg := image.NewRGBA(i.outerBounds)
+	draw.Draw(bg, bg.Bounds(), &image.Uniform{i.fillColor}, image.Point{}, draw.Src)
+	centerH := math.Abs(float64(i.outerBounds.Max.Y-bounds.Max.Y)) / 2.0
+	centerW := math.Abs(float64(i.outerBounds.Max.X-bounds.Max.X)) / 2.0
+	center := bounds.Min.Sub(image.Pt(int(centerW), int(centerH)))
+	draw.Draw(bg, bg.Bounds(), dest, center, draw.Over)
+	i.img = bg
+}
+
+func (i *Image) ResizeAndFill(w, h uint, c color.Color) {
+	if w == 0 || h == 0 {
+		return
+	}
+	innerW := w
+	innerH := h
+	r := i.img.Bounds()
+	if int(innerW)*r.Max.Y < int(innerH)*r.Max.X {
+		innerH = 0
 	} else {
-		return 0, h
+		innerW = 0
 	}
+	i.filter.Add(gift.Resize(int(innerW), int(innerH), gift.LanczosResampling))
+	i.outerBounds = image.Rect(0, 0, int(w), int(h))
+	i.fillColor = c
 }
 
-func resizeImage(img image.Image, w uint, h uint, maxWidth uint, maxHeight uint) image.Image {
-	if img == nil {
-		return nil
-	}
-	//大きすぎる値はサポートしない
-	w = max(w, maxWidth)
-	h = max(h, maxHeight)
-	w, h = keepAspect(img, w, h)
-	// 速度・負荷的な問題出た時はアルゴリズム変更
-	return resize.Resize(w, h, img, resize.Lanczos3)
-}
-
-func resizeAndFillImage(img image.Image, w uint, h uint, c color.Color, maxWidth uint, maxHeight uint) image.Image {
-	if img == nil {
-		return nil
-	}
-	if maxWidth < w || maxHeight < h {
-		return img
-	}
-	ch0 := make(chan image.Image)
-	ch1 := make(chan *image.RGBA)
-
-	// ココらへんの並列化はベンチマーク次第で変更する
-	go func() {
-		ch0 <- resizeImage(img, w, h, maxWidth, maxHeight)
-	}()
-	go func() {
-		ch1 <- image.NewRGBA(image.Rect(0, 0, int(w), int(h)))
-	}()
-	resizedImage := <-ch0
-	m := <-ch1
-
-	zeroPoint := image.Point{}
-	draw.Draw(m, m.Bounds(), &image.Uniform{c}, zeroPoint, draw.Src)
-
-	//画像の中心座標を計算
-	centerH := int(h)/2 - (resizedImage.Bounds().Max.Y / 2)
-	centerW := int(w)/2 - (resizedImage.Bounds().Max.X / 2)
-
-	if resizedImage.Bounds().Max.X == int(w) {
-		draw.Draw(m, m.Bounds(), resizedImage, resizedImage.Bounds().Min.Sub(image.Pt(0, centerH)), draw.Over)
-	} else if resizedImage.Bounds().Max.Y == int(h) {
-		draw.Draw(m, m.Bounds(), resizedImage, resizedImage.Bounds().Min.Sub(image.Pt(centerW, 0)), draw.Over)
-	} else {
-		return resizedImage
-	}
-	return m
-}
-
-func (i *Image) ResizeAndFill(w uint, h uint, c color.Color, maxW uint, maxH uint) {
-	if maxW < w || maxH < h {
+func (i *Image) Crop(w, h uint) {
+	if w == 0 || h == 0 {
 		return
 	}
-	if h == 0 || w == 0 {
-		return
-	}
-	if c == nil {
-		i.img = resizeImage(i.img, w, h, maxW, maxH)
-		return
-	}
-	i.img = resizeAndFillImage(i.img, w, h, c, maxW, maxH)
+	i.filter.Add(gift.ResizeToFill(int(w), int(h), gift.LanczosResampling, gift.CenterAnchor))
+	i.outerBounds = image.Rect(0, 0, int(w), int(h))
 }
 
-func crop(img image.Image, w uint, h uint) image.Image {
-	if img == nil {
-		return nil
+func (i *Image) ApplyOrientation() {
+	if affine, ok := affines[i.orientation]; ok {
+		i.filter.Add(affine)
 	}
-	if h == 0 || w == 0 {
-		return img
-	}
-
-	orgW := img.Bounds().Max.X
-	orgH := img.Bounds().Max.Y
-
-	r := float64(orgW) / float64(w)
-	if (float64(orgW) / float64(orgH)) > (float64(w) / float64(h)) {
-		r = float64(orgH) / float64(h)
-	}
-
-	startW := orgW/2 - int(float64(w)*r/2)
-	startH := orgH/2 - int(float64(h)*r/2)
-
-	result := image.NewRGBA(image.Rect(0, 0, int(float64(w)*r), int(float64(h)*r)))
-
-	for y := 0; y < int(float64(h)*r); y++ {
-		for x := 0; x < int(float64(w)*r); x++ {
-			c := img.At(x+startW, y+startH)
-			result.Set(x, y, c)
-		}
-	}
-
-	return result
-}
-
-func (i *Image) Crop(w uint, h uint) {
-	i.img = crop(i.img, w, h)
 }
 
 func (i *Image) GetImg() *image.Image {
@@ -310,36 +259,13 @@ func (i *Image) GetFormat() string {
 	return i.format
 }
 
-func Set404Image(buf io.Writer, data io.Reader, w uint, h uint, c color.Color, maxW uint, maxH uint) error {
+func Set404Image(buf io.Writer, data io.Reader, w uint, h uint, c color.Color) error {
 	img, err := DecodeImage(data)
 	if err != nil {
 		return imgproxyerr.New(imgproxyerr.ERROR, err)
 	}
-	img.ResizeAndFill(w, h, c, maxW, maxH)
+	img.ResizeAndFill(w, h, c)
 	return EncodeJpeg(buf, img.GetImg(), jpeg.DefaultQuality)
-}
-
-func toRadian(n int) float64 {
-	return float64(n) * math.Pi / 180.0
-}
-
-func applyOrientation(s image.Image, o int) (d draw.Image, e error) {
-	bounds := s.Bounds()
-	if o == 0 {
-		o = 1
-	}
-	if o >= 5 && o <= 8 {
-		bounds = rotateRect(bounds)
-	}
-	d = image.NewRGBA(bounds)
-	affine := affines[o]
-	e = affine.TransformCenter(d, s, interp.Bilinear)
-	return
-}
-
-func rotateRect(r image.Rectangle) image.Rectangle {
-	s := r.Size()
-	return image.Rectangle{r.Min, image.Point{s.Y, s.X}}
 }
 
 func readOrientation(r io.Reader) (o int, err error) {
@@ -358,19 +284,15 @@ func readOrientation(r io.Reader) (o int, err error) {
 	return
 }
 
-func decode(r io.Reader) (d image.Image, format string, err error) {
+func decode(r io.Reader) (d image.Image, format string, o int, err error) {
 	var buf bytes.Buffer
 	tee := io.TeeReader(r, &buf)
 
-	s, format, err := image.Decode(tee)
+	d, format, err = image.Decode(tee)
 	if err != nil {
 		return
 	}
 
-	o, err := readOrientation(&buf)
-	if err != nil {
-		return s, format, nil
-	}
-	d, err = applyOrientation(s, o)
+	o, _ = readOrientation(&buf)
 	return
 }

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -83,13 +83,6 @@ func (i *Image) ConvertColor(networkPath string) error {
 	return nil
 }
 
-func max(v uint, max uint) uint {
-	if v > max {
-		return max
-	}
-	return v
-}
-
 func EncodeJpeg(buf io.Writer, img *image.Image, q int) error {
 	if *img == nil {
 		return imgproxyerr.New(imgproxyerr.WARNING, errors.New("img is nil"))

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -263,6 +263,7 @@ func Set404Image(buf io.Writer, data io.Reader, w uint, h uint, c color.Color) e
 		return imgproxyerr.New(imgproxyerr.ERROR, err)
 	}
 	img.ResizeAndFill(w, h, c)
+	img.Process()
 	return EncodeJpeg(buf, img.GetImg(), jpeg.DefaultQuality)
 }
 

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -191,14 +191,16 @@ func EncodeAVIF(buf io.Writer, img *image.Image, q int) error {
 
 func DecodeImage(r io.Reader) (*Image, error) {
 	img, format, orientation, err := decode(r)
-	wrapper := Image{
+	if err != nil {
+		return nil, imgproxyerr.New(imgproxyerr.WARNING, err)
+	}
+	return &Image{
 		img:         img,
 		format:      format,
 		orientation: orientation,
 		outerBounds: img.Bounds(),
 		filter:      gift.New(),
-	}
-	return &wrapper, imgproxyerr.New(imgproxyerr.WARNING, err)
+	}, nil
 }
 
 func (i *Image) Process() {
@@ -252,6 +254,9 @@ func (i *Image) ApplyOrientation() {
 }
 
 func (i *Image) GetImg() *image.Image {
+	if i.img == nil {
+		return nil
+	}
 	return &i.img
 }
 

--- a/lib/image/image_test.go
+++ b/lib/image/image_test.go
@@ -38,14 +38,12 @@ func TestEncodeJpeg(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	err = EncodeJpeg(&b, img.GetImg(), -1)
-	if err != nil {
+	if err := EncodeJpeg(&b, img.GetImg(), -1); err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
-	img, err = DecodeImage(confBin)
-	if err == nil {
+	if _, err := DecodeImage(confBin); err == nil {
 		t.Fatal("no error")
 	}
 	b.Reset()
@@ -63,8 +61,7 @@ func BenchmarkEncodeJpeg(b *testing.B) {
 		}
 
 		var buf bytes.Buffer
-		err = EncodeJpeg(&buf, img.GetImg(), -1)
-		if err != nil {
+		if err := EncodeJpeg(&buf, img.GetImg(), -1); err != nil {
 			log.Fatalf("err is %v.", err)
 		}
 		buf.Reset()
@@ -82,14 +79,12 @@ func TestEncodePNG(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	err = EncodePNG(&b, img.GetImg(), -1)
-	if err != nil {
+	if err := EncodePNG(&b, img.GetImg(), -1); err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
-	img, err = DecodeImage(confBin)
-	if err == nil {
+	if _, err := DecodeImage(confBin); err == nil {
 		t.Fatal("no error")
 	}
 	b.Reset()
@@ -106,14 +101,12 @@ func TestEncodeGIF(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	err = EncodeGIF(&b, img.GetImg(), -1)
-	if err != nil {
+	if err := EncodeGIF(&b, img.GetImg(), -1); err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
-	img, err = DecodeImage(confBin)
-	if err == nil {
+	if _, err = DecodeImage(confBin); err == nil {
 		t.Fatal("no error")
 	}
 	b.Reset()
@@ -131,8 +124,7 @@ func TestEncodeWebP(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	err = EncodeWebP(&b, img.GetImg(), -1, true)
-	if err != nil {
+	if err := EncodeWebP(&b, img.GetImg(), -1, true); err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
@@ -147,15 +139,13 @@ func TestEncodeWebP(t *testing.T) {
 		t.Fatalf("format is %v, expected webp", format)
 	}
 
-	err = EncodeWebP(&b, img.GetImg(), -1, false)
-	if err != nil {
+	if err := EncodeWebP(&b, img.GetImg(), -1, false); err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
 	// error
-	img, err = DecodeImage(confBin)
-	if err == nil {
+	if _, err := DecodeImage(confBin); err == nil {
 		t.Fatal("no error")
 	}
 	b.Reset()
@@ -174,8 +164,7 @@ func TestEncodeAVIF(t *testing.T) {
 	}
 	b.Reset()
 
-	img, err = DecodeImage(confBin)
-	if err == nil {
+	if _, err := DecodeImage(confBin); err == nil {
 		t.Fatal("no error")
 	}
 	b.Reset()

--- a/lib/image/image_test.go
+++ b/lib/image/image_test.go
@@ -2,7 +2,6 @@ package imageprocessor
 
 import (
 	"bytes"
-	"image/color"
 	"log"
 	"os"
 	"testing"
@@ -28,121 +27,121 @@ var (
 	confBin, _         = os.Open(confPath)
 )
 
-var ResizeImage = resizeImage
-var ResizeAndFillImage = resizeAndFillImage
-var Crop = crop
-
 func TestEncodeJpeg(t *testing.T) {
-	img, _ := DecodeImage(jpegBin)
+	img, err := DecodeImage(jpegBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	jpegBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "jpeg" {
 		t.Fatalf("format is %v, expected jpeg", format)
 	}
 
 	var b bytes.Buffer
-	err := EncodeJpeg(&b, img.GetImg(), -1)
+	err = EncodeJpeg(&b, img.GetImg(), -1)
 	if err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
-	confBin.Seek(0, 0)
-	err = EncodeJpeg(&b, img.GetImg(), 50)
+	img, err = DecodeImage(confBin)
 	if err == nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal("no error")
 	}
 	b.Reset()
 }
 
 func BenchmarkEncodeJpeg(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		img, _ := DecodeImage(jpegBin)
+		img, err := DecodeImage(jpegBin)
+		if err != nil {
+			b.Fatal(err)
+		}
 		jpegBin.Seek(0, 0)
 		if format := img.GetFormat(); format != "jpeg" {
 			log.Fatalf("format is %v, expected jpeg", format)
 		}
 
-		var b bytes.Buffer
-		err := EncodeJpeg(&b, img.GetImg(), -1)
+		var buf bytes.Buffer
+		err = EncodeJpeg(&buf, img.GetImg(), -1)
 		if err != nil {
 			log.Fatalf("err is %v.", err)
 		}
-		b.Reset()
-
-		img, _ = DecodeImage(confBin)
-		confBin.Seek(0, 0)
-		err = EncodeJpeg(&b, img.GetImg(), 50)
-		if err == nil {
-			log.Fatalf("err is %v.", err)
-		}
-		b.Reset()
+		buf.Reset()
 	}
 }
 
 func TestEncodePNG(t *testing.T) {
-	img, _ := DecodeImage(pngBin)
+	img, err := DecodeImage(pngBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	pngBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "png" {
 		t.Fatalf("format is %v, expected png", format)
 	}
 
 	var b bytes.Buffer
-	err := EncodePNG(&b, img.GetImg(), -1)
+	err = EncodePNG(&b, img.GetImg(), -1)
 	if err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
-	confBin.Seek(0, 0)
-	err = EncodePNG(&b, img.GetImg(), 50)
+	img, err = DecodeImage(confBin)
 	if err == nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal("no error")
 	}
 	b.Reset()
 }
 
 func TestEncodeGIF(t *testing.T) {
-	img, _ := DecodeImage(gifBin)
+	img, err := DecodeImage(gifBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	gifBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "gif" {
 		t.Fatalf("format is %v, expected png", format)
 	}
 
 	var b bytes.Buffer
-	err := EncodeGIF(&b, img.GetImg(), -1)
+	err = EncodeGIF(&b, img.GetImg(), -1)
 	if err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
-	confBin.Seek(0, 0)
-	err = EncodeGIF(&b, img.GetImg(), 50)
+	img, err = DecodeImage(confBin)
 	if err == nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal("no error")
 	}
 	b.Reset()
 }
 
 func TestEncodeWebP(t *testing.T) {
 	// Lossless
-	img, _ := DecodeImage(webpLosslessBin)
+	img, err := DecodeImage(webpLosslessBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	webpLosslessBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
 	}
 
 	var b bytes.Buffer
-	err := EncodeWebP(&b, img.GetImg(), -1, true)
+	err = EncodeWebP(&b, img.GetImg(), -1, true)
 	if err != nil {
 		t.Fatalf("err is %v.", err)
 	}
 	b.Reset()
 
 	// Lossy
-	img, _ = DecodeImage(webpLossyBin)
+	img, err = DecodeImage(webpLossyBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	webpLossyBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
@@ -155,11 +154,9 @@ func TestEncodeWebP(t *testing.T) {
 	b.Reset()
 
 	// error
-	img, _ = DecodeImage(confBin)
-	confBin.Seek(0, 0)
-	err = EncodeWebP(&b, img.GetImg(), 50, true)
+	img, err = DecodeImage(confBin)
 	if err == nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal("no error")
 	}
 	b.Reset()
 }
@@ -167,318 +164,62 @@ func TestEncodeWebP(t *testing.T) {
 func TestEncodeAVIF(t *testing.T) {
 	var b bytes.Buffer
 
-	img, _ := DecodeImage(pngBin)
+	img, err := DecodeImage(pngBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	pngBin.Seek(0, 0)
 	if err := EncodeAVIF(&b, img.GetImg(), 50); err != nil {
 		t.Fatal(err)
 	}
 	b.Reset()
 
-	img, _ = DecodeImage(confBin)
-	pngBin.Seek(0, 0)
-	if err := EncodeAVIF(&b, img.GetImg(), 50); err == nil {
-		t.Fatal("err is nil")
+	img, err = DecodeImage(confBin)
+	if err == nil {
+		t.Fatal("no error")
 	}
 	b.Reset()
 }
 
 func TestDecodeImage(t *testing.T) {
-	img, err := DecodeImage(jpegBin)
-	jpegBin.Seek(0, 0)
-	if err != nil {
+	if _, err := DecodeImage(jpegBin); err != nil {
 		t.Log(err)
 		t.Fatalf("err is not nil.")
 	}
-	if img == nil {
-		t.Fatalf("can not decode.")
-	}
+	jpegBin.Seek(0, 0)
 
-	img, err = DecodeImage(bmpBin)
-	bmpBin.Seek(0, 0)
-	if err != nil {
+	if _, err := DecodeImage(bmpBin); err != nil {
 		t.Fatalf("err is not nil. : %v", err)
 	}
-	if img == nil {
-		t.Fatalf("img.%v", img)
-	}
+	bmpBin.Seek(0, 0)
 
-	img, err = DecodeImage(pngBin)
+	if _, err := DecodeImage(pngBin); err != nil {
+		t.Log(err)
+		t.Fatalf("err is not nil.")
+	}
 	pngBin.Seek(0, 0)
-	if err != nil {
+
+	if _, err := DecodeImage(gifBin); err != nil {
 		t.Log(err)
 		t.Fatalf("err is not nil.")
 	}
-	if img == nil {
-		t.Fatalf("can not decode.")
-	}
-
-	img, err = DecodeImage(gifBin)
 	gifBin.Seek(0, 0)
-	if err != nil {
+
+	if _, err := DecodeImage(webpLosslessBin); err != nil {
 		t.Log(err)
 		t.Fatalf("err is not nil.")
 	}
-	if img == nil {
-		t.Fatalf("can not decode.")
-	}
-
-	img, err = DecodeImage(webpLosslessBin)
 	webpLosslessBin.Seek(0, 0)
-	if err != nil {
+
+	if _, err := DecodeImage(webpLossyBin); err != nil {
 		t.Log(err)
 		t.Fatalf("err is not nil.")
 	}
-	if img == nil {
-		t.Fatalf("can not decode.")
-	}
-
-	img, err = DecodeImage(webpLossyBin)
 	webpLossyBin.Seek(0, 0)
-	if err != nil {
-		t.Log(err)
-		t.Fatalf("err is not nil.")
-	}
-	if img == nil {
-		t.Fatalf("can not decode.")
-	}
 
-	img, err = DecodeImage(confBin)
-	confBin.Seek(0, 0)
-	if err == nil {
+	if _, err := DecodeImage(confBin); err == nil {
 		t.Log(err)
 		t.Fatalf("err is nil")
 	}
-
-	if img == nil {
-		t.Fatalf("can not decode.")
-	}
-}
-
-func TestResizeImage(t *testing.T) {
-	img, _ := DecodeImage(confBin)
 	confBin.Seek(0, 0)
-
-	resizeImg := ResizeImage(*img.GetImg(), 100, 100, 10000, 10000)
-	if resizeImg != nil {
-		t.Fatalf("value is not nil.")
-	}
-
-	img, _ = DecodeImage(jpegBin)
-	jpegBin.Seek(0, 0)
-	ii := *img.GetImg()
-	jpegRect := ii.Bounds()
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X*2), uint(jpegRect.Max.Y*2), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X), uint(jpegRect.Max.Y), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X*100000), uint(jpegRect.Max.Y*100000), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X), uint(jpegRect.Max.Y*100000), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X*100000), uint(jpegRect.Max.Y), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X), uint(jpegRect.Max.Y+1000), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X+1000), uint(jpegRect.Max.Y), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X), uint(jpegRect.Max.Y-100), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), uint(jpegRect.Max.X-100), uint(jpegRect.Max.Y), 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-
-	resizeImg = ResizeImage(*img.GetImg(), 0, 0, 10000, 10000)
-	if resizeImg == nil {
-		t.Fatalf("value is nil.")
-	}
-}
-
-func TestResizeAndFillImage(t *testing.T) {
-	c := color.RGBA{
-		R: 0xff,
-		G: 0xff,
-		B: 0xff,
-		A: 0xff,
-	}
-	img, _ := DecodeImage(confBin)
-	confBin.Seek(0, 0)
-
-	fillImg := ResizeAndFillImage(*img.GetImg(), 100, 100, c, 10000, 10000)
-	if fillImg != nil {
-		t.Fatalf("value is not nil.")
-	}
-
-	img, _ = DecodeImage(pngBin)
-	pngBin.Seek(0, 0)
-
-	fillImg = ResizeAndFillImage(*img.GetImg(), 100, 100, c, 10000, 10000)
-	if fillImg == nil {
-		t.Fatalf("value is nil.")
-	}
-	if fillImg.Bounds().Max.X != 100 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-	if fillImg.Bounds().Max.Y != 100 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-
-	fillImg = ResizeAndFillImage(*img.GetImg(), 1000, 100, c, 10000, 10000)
-	if fillImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if fillImg.Bounds().Max.X != 1000 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-	if fillImg.Bounds().Max.Y != 100 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-
-	fillImg = ResizeAndFillImage(*img.GetImg(), 100, 1000, c, 10000, 10000)
-	if fillImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if fillImg.Bounds().Max.X != 100 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-	if fillImg.Bounds().Max.Y != 1000 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-
-	fillImg = ResizeAndFillImage(*img.GetImg(), 5000, 5000, c, 10000, 10000)
-	if fillImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if fillImg.Bounds().Max.X != 5000 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-	if fillImg.Bounds().Max.Y != 5000 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-
-	fillImg = ResizeAndFillImage(*img.GetImg(), 0, 0, c, 10000, 10000)
-	if fillImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if fillImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-	if fillImg.Bounds().Max.Y != 512 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-
-	fillImg = ResizeAndFillImage(*img.GetImg(), 1000000, 1000000, c, 10000, 10000)
-	if fillImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if fillImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-	if fillImg.Bounds().Max.Y != 512 {
-		t.Fatalf("x is %v.", fillImg.Bounds().Max.X)
-	}
-}
-
-func TestCrop(t *testing.T) {
-	img, _ := DecodeImage(confBin)
-	confBin.Seek(0, 0)
-
-	cropImg := Crop(*img.GetImg(), 100, 100)
-	if cropImg != nil {
-		t.Fatalf("value is not nil.")
-	}
-
-	img, _ = DecodeImage(pngBin)
-	pngBin.Seek(0, 0)
-
-	cropImg = Crop(*img.GetImg(), 100, 100)
-	if cropImg == nil {
-		t.Fatalf("value is nil.")
-	}
-	if cropImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", cropImg.Bounds().Max.X)
-	}
-	if cropImg.Bounds().Max.Y != 512 {
-		t.Fatalf("y is %v.", cropImg.Bounds().Max.Y)
-	}
-
-	cropImg = Crop(*img.GetImg(), 1000, 100)
-	if cropImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if cropImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", cropImg.Bounds().Max.X)
-	}
-	if cropImg.Bounds().Max.Y != 51 {
-		t.Fatalf("y is %v.", cropImg.Bounds().Max.Y)
-	}
-
-	cropImg = Crop(*img.GetImg(), 100, 1000)
-	if cropImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if cropImg.Bounds().Max.X != 51 {
-		t.Fatalf("x is %v.", cropImg.Bounds().Max.X)
-	}
-	if cropImg.Bounds().Max.Y != 512 {
-		t.Fatalf("y is %v.", cropImg.Bounds().Max.Y)
-	}
-
-	cropImg = Crop(*img.GetImg(), 5000, 5000)
-	if cropImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if cropImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", cropImg.Bounds().Max.X)
-	}
-	if cropImg.Bounds().Max.Y != 512 {
-		t.Fatalf("y is %v.", cropImg.Bounds().Max.Y)
-	}
-
-	cropImg = Crop(*img.GetImg(), 0, 0)
-	if cropImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if cropImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", cropImg.Bounds().Max.X)
-	}
-	if cropImg.Bounds().Max.Y != 512 {
-		t.Fatalf("y is %v.", cropImg.Bounds().Max.Y)
-	}
-
-	cropImg = Crop(*img.GetImg(), 1000000, 1000000)
-	if cropImg == nil {
-		t.Fatalf("value is not nil.")
-	}
-	if cropImg.Bounds().Max.X != 512 {
-		t.Fatalf("x is %v.", cropImg.Bounds().Max.X)
-	}
-	if cropImg.Bounds().Max.Y != 512 {
-		t.Fatalf("y is %v.", cropImg.Bounds().Max.Y)
-	}
 }

--- a/lib/image/image_test.go
+++ b/lib/image/image_test.go
@@ -2,6 +2,7 @@ package imageprocessor
 
 import (
 	"bytes"
+	"image/color"
 	"log"
 	"os"
 	"testing"
@@ -29,22 +30,23 @@ var (
 
 func TestEncodeJpeg(t *testing.T) {
 	img, err := DecodeImage(jpegBin)
+	jpegBin.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	jpegBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "jpeg" {
 		t.Fatalf("format is %v, expected jpeg", format)
 	}
 
 	var b bytes.Buffer
 	if err := EncodeJpeg(&b, img.GetImg(), -1); err != nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal(err)
 	}
 	b.Reset()
 
+	defer confBin.Seek(0, 0)
 	if _, err := DecodeImage(confBin); err == nil {
-		t.Fatal("no error")
+		t.Error("no error")
 	}
 	b.Reset()
 }
@@ -52,17 +54,17 @@ func TestEncodeJpeg(t *testing.T) {
 func BenchmarkEncodeJpeg(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		img, err := DecodeImage(jpegBin)
+		jpegBin.Seek(0, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
-		jpegBin.Seek(0, 0)
 		if format := img.GetFormat(); format != "jpeg" {
 			log.Fatalf("format is %v, expected jpeg", format)
 		}
 
 		var buf bytes.Buffer
 		if err := EncodeJpeg(&buf, img.GetImg(), -1); err != nil {
-			log.Fatalf("err is %v.", err)
+			log.Fatal(err)
 		}
 		buf.Reset()
 	}
@@ -70,44 +72,46 @@ func BenchmarkEncodeJpeg(b *testing.B) {
 
 func TestEncodePNG(t *testing.T) {
 	img, err := DecodeImage(pngBin)
+	pngBin.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pngBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "png" {
 		t.Fatalf("format is %v, expected png", format)
 	}
 
 	var b bytes.Buffer
 	if err := EncodePNG(&b, img.GetImg(), -1); err != nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal(err)
 	}
 	b.Reset()
 
+	defer confBin.Seek(0, 0)
 	if _, err := DecodeImage(confBin); err == nil {
-		t.Fatal("no error")
+		t.Error("no error")
 	}
 	b.Reset()
 }
 
 func TestEncodeGIF(t *testing.T) {
 	img, err := DecodeImage(gifBin)
+	gifBin.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gifBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "gif" {
 		t.Fatalf("format is %v, expected png", format)
 	}
 
 	var b bytes.Buffer
 	if err := EncodeGIF(&b, img.GetImg(), -1); err != nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal(err)
 	}
 	b.Reset()
 
+	defer confBin.Seek(0, 0)
 	if _, err = DecodeImage(confBin); err == nil {
-		t.Fatal("no error")
+		t.Error("no error")
 	}
 	b.Reset()
 }
@@ -115,38 +119,39 @@ func TestEncodeGIF(t *testing.T) {
 func TestEncodeWebP(t *testing.T) {
 	// Lossless
 	img, err := DecodeImage(webpLosslessBin)
+	webpLosslessBin.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	webpLosslessBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
 	}
 
 	var b bytes.Buffer
 	if err := EncodeWebP(&b, img.GetImg(), -1, true); err != nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal(err)
 	}
 	b.Reset()
 
 	// Lossy
 	img, err = DecodeImage(webpLossyBin)
+	webpLossyBin.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	webpLossyBin.Seek(0, 0)
 	if format := img.GetFormat(); format != "webp" {
 		t.Fatalf("format is %v, expected webp", format)
 	}
 
 	if err := EncodeWebP(&b, img.GetImg(), -1, false); err != nil {
-		t.Fatalf("err is %v.", err)
+		t.Fatal(err)
 	}
 	b.Reset()
 
 	// error
+	defer confBin.Seek(0, 0)
 	if _, err := DecodeImage(confBin); err == nil {
-		t.Fatal("no error")
+		t.Error("no error")
 	}
 	b.Reset()
 }
@@ -155,60 +160,76 @@ func TestEncodeAVIF(t *testing.T) {
 	var b bytes.Buffer
 
 	img, err := DecodeImage(pngBin)
+	pngBin.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pngBin.Seek(0, 0)
 	if err := EncodeAVIF(&b, img.GetImg(), 50); err != nil {
 		t.Fatal(err)
 	}
 	b.Reset()
 
+	defer confBin.Seek(0, 0)
 	if _, err := DecodeImage(confBin); err == nil {
-		t.Fatal("no error")
+		t.Error("no error")
 	}
 	b.Reset()
 }
 
 func TestDecodeImage(t *testing.T) {
 	if _, err := DecodeImage(jpegBin); err != nil {
-		t.Log(err)
-		t.Fatalf("err is not nil.")
+		t.Error(err)
 	}
-	jpegBin.Seek(0, 0)
+	defer jpegBin.Seek(0, 0)
 
 	if _, err := DecodeImage(bmpBin); err != nil {
-		t.Fatalf("err is not nil. : %v", err)
+		t.Error(err)
 	}
-	bmpBin.Seek(0, 0)
+	defer bmpBin.Seek(0, 0)
 
 	if _, err := DecodeImage(pngBin); err != nil {
-		t.Log(err)
-		t.Fatalf("err is not nil.")
+		t.Error(err)
 	}
-	pngBin.Seek(0, 0)
+	defer pngBin.Seek(0, 0)
 
 	if _, err := DecodeImage(gifBin); err != nil {
-		t.Log(err)
-		t.Fatalf("err is not nil.")
+		t.Error(err)
 	}
-	gifBin.Seek(0, 0)
+	defer gifBin.Seek(0, 0)
 
 	if _, err := DecodeImage(webpLosslessBin); err != nil {
-		t.Log(err)
-		t.Fatalf("err is not nil.")
+		t.Error(err)
 	}
-	webpLosslessBin.Seek(0, 0)
+	defer webpLosslessBin.Seek(0, 0)
 
 	if _, err := DecodeImage(webpLossyBin); err != nil {
-		t.Log(err)
-		t.Fatalf("err is not nil.")
+		t.Error(err)
 	}
-	webpLossyBin.Seek(0, 0)
+	defer webpLossyBin.Seek(0, 0)
 
 	if _, err := DecodeImage(confBin); err == nil {
-		t.Log(err)
-		t.Fatalf("err is nil")
+		t.Error("err is nil")
 	}
-	confBin.Seek(0, 0)
+	defer confBin.Seek(0, 0)
+}
+
+func TestImageProcess(t *testing.T) {
+	img, err := DecodeImage(jpegBin)
+	jpegBin.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img.ApplyOrientation()
+	img.ResizeAndFill(1618, 1000, color.RGBA{uint8(32), uint8(32), uint8(32), 0xff})
+	img.Process()
+
+	innerP := img.GetImg()
+	inner := *innerP
+	if inner.Bounds().Max.X != 1618 {
+		t.Errorf("want=%d, got=%d", 1618, inner.Bounds().Max.X)
+	}
+	if inner.Bounds().Max.Y != 1000 {
+		t.Errorf("want=%d, got=%d", 1000, inner.Bounds().Max.Y)
+	}
 }


### PR DESCRIPTION
## Problem
The following process is too slow. It spends lots of cpu time and memory allocation. It looks like a bottleneck.
https://github.com/livesense-inc/fanlin/blob/45a1655871dda0fa9b19840888af028705d93b78/lib/image/image.go#L336

The above process depends on the following library. Unfortunately, the last update is a decade ago.
https://github.com/BurntSushi/graphics-go

CPU
```
      flat  flat%   sum%        cum   cum%
     280ms 17.95% 17.95%      280ms 17.95%  github.com/nfnt/resize.resizeRGBA
     220ms 14.10% 32.05%      730ms 46.79%  github.com/BurntSushi/graphics-go/graphics/interp.bilinearGeneral
     150ms  9.62% 41.67%      230ms 14.74%  runtime.mallocgc
      70ms  4.49% 46.15%       70ms  4.49%  image/color.YCbCr.RGBA
      70ms  4.49% 50.64%      300ms 19.23%  image/jpeg.(*decoder).processSOS
      70ms  4.49% 55.13%      110ms  7.05%  image/jpeg.(*decoder).reconstructBlock
      60ms  3.85% 58.97%       60ms  3.85%  github.com/BurntSushi/graphics-go/graphics/interp.findLinearSrc
      60ms  3.85% 62.82%       60ms  3.85%  runtime.deductAssistCredit
      50ms  3.21% 66.03%       60ms  3.85%  image/jpeg.(*decoder).receiveExtend
      50ms  3.21% 69.23%      330ms 21.15%  runtime.convTnoptr
```

Memory
```
      flat  flat%   sum%        cum   cum%
      83MB 33.11% 33.11%       83MB 33.11%  image.(*YCbCr).At
   81.50MB 32.52% 65.63%   164.50MB 65.63%  github.com/BurntSushi/graphics-go/graphics/interp.bilinearGeneral
   39.15MB 15.62% 81.25%    39.15MB 15.62%  bytes.growSlice
   27.04MB 10.79% 92.03%    27.04MB 10.79%  image.NewRGBA
   15.45MB  6.16% 98.20%    15.45MB  6.16%  image.NewYCbCr
    1.51MB   0.6% 98.80%     1.51MB   0.6%  io.ReadAll
         0     0% 98.80%    23.02MB  9.19%  bufio.(*Reader).Read
         0     0% 98.80%    16.12MB  6.43%  bytes.(*Buffer).ReadFrom
         0     0% 98.80%    23.02MB  9.19%  bytes.(*Buffer).Write
         0     0% 98.80%    39.15MB 15.62%  bytes.(*Buffer).grow
```

## Solution
I found an awesome library which is named "gift". It is also used in [hugo](https://github.com/gohugoio/hugo) project.
https://github.com/disintegration/gift

So I think we need to migrate some libraries to the gift for the performance improvement.

* https://github.com/BurntSushi/graphics-go
  * The last update is a decade ago.
* https://github.com/nfnt/resize
  * repository archived
  * We can use Lanczos algorithm for interpolation by the gift as well.

Several operations for our image processing can be done by only the gift.

* applying orientation
* cropping
* resize

The gift can do processing in parallel as default. We can pass several filters to it, then we can draw image at last.

## Benchmark
### Before
```
$ echo 'GET http://127.0.0.1:3000/baz/Lenna.jpg?w=300&h=200&rgb=32,32,32' | vegeta attack -header='user-agent: vegeta' -rate=50 -duration=180s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         9000, 50.01, 49.98
Duration      [total, attack, wait]             3m0s, 3m0s, 88.627ms
Latencies     [min, mean, 50, 90, 95, 99, max]  87.575ms, 94.242ms, 93.583ms, 98.539ms, 100.593ms, 105.215ms, 116.145ms
Bytes In      [total, mean]                     87327000, 9703.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:9000
Error Set:
```

### After
```
$ echo 'GET http://127.0.0.1:3000/baz/Lenna.jpg?w=300&h=200&rgb=32,32,32' | vegeta attack -header='user-agent: vegeta' -rate=50 -duration=180s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         9000, 50.01, 50.00
Duration      [total, attack, wait]             3m0s, 3m0s, 29.395ms
Latencies     [min, mean, 50, 90, 95, 99, max]  28.803ms, 30.883ms, 30.859ms, 31.896ms, 32.219ms, 32.924ms, 43.37ms
Bytes In      [total, mean]                     87183000, 9687.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:9000
Error Set:
```

![3_times_faster](https://github.com/user-attachments/assets/c8c25063-847d-40ba-9935-7b4fbd49da44)
(c) Bandai Namco Holdings, Sotsu

## Related links
* https://pkg.go.dev/github.com/disintegration/gift
* https://pkg.go.dev/image
* #91
* #56