### PR TITLE
Remove stacktrace from log

### DIFF
--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"runtime/debug"
 	"time"
 
 	configure "github.com/livesense-inc/fanlin/lib/conf"
@@ -90,7 +89,6 @@ func fallback(
 		log.Println(err)
 	}
 	fmt.Fprintf(w, "%s", "")
-	debug.PrintStack()
 }
 
 func writeDebugLog(err interface{}, debugFile string) {


### PR DESCRIPTION
Since the following pull request got rid of panic handlings, I think the stacktrace information is no longer needed in log.

* #73