### PR TITLE
feat: add grayscale and inverse parameters to query

### DIFF
--- a/lib/handler/handler.go
+++ b/lib/handler/handler.go
@@ -190,6 +190,11 @@ func processImage(buf io.Reader, conf *configure.Conf, q *query.Query) (*imagepr
 	} else {
 		img.ResizeAndFill(w, h, *q.FillColor())
 	}
+	if q.Grayscale() {
+		img.Grayscale()
+	} else if q.Inverse() {
+		img.Invert()
+	}
 	img.Process()
 	return img, nil
 }

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -240,6 +240,14 @@ func (i *Image) Crop(w, h uint) {
 	i.outerBounds = image.Rect(0, 0, int(w), int(h))
 }
 
+func (i *Image) Invert() {
+	i.filter.Add(gift.Invert())
+}
+
+func (i *Image) Grayscale() {
+	i.filter.Add(gift.Grayscale())
+}
+
 func (i *Image) ApplyOrientation() {
 	if affine, ok := affines[i.orientation]; ok {
 		i.filter.Add(affine)

--- a/lib/query/query.go
+++ b/lib/query/query.go
@@ -17,6 +17,8 @@ type Query struct {
 	fillColor color.Color
 	crop      bool
 	quality   int
+	grayscale bool
+	inverse   bool
 	useWebp   bool
 	useAvif   bool
 }
@@ -50,6 +52,16 @@ func NewQueryFromGet(r *http.Request) *Query {
 		crop = false
 	}
 
+	grayscale, err := strconv.ParseBool(params.Get("grayscale"))
+	if err != nil {
+		grayscale = false
+	}
+
+	inverse, err := strconv.ParseBool(params.Get("inverse"))
+	if err != nil {
+		inverse = false
+	}
+
 	webp, err := strconv.ParseBool(params.Get("webp"))
 	if err != nil {
 		webp = false
@@ -65,6 +77,8 @@ func NewQueryFromGet(r *http.Request) *Query {
 	q.fillColor = c
 	q.crop = crop
 	q.quality = quality
+	q.grayscale = grayscale
+	q.inverse = inverse
 	q.useWebp = webp
 	q.useAvif = avif
 	return &q
@@ -84,6 +98,14 @@ func (q *Query) Crop() bool {
 
 func (q *Query) Quality() int {
 	return q.quality
+}
+
+func (q *Query) Grayscale() bool {
+	return q.grayscale
+}
+
+func (q *Query) Inverse() bool {
+	return q.inverse
 }
 
 func (q *Query) UseWebP() bool {

--- a/lib/query/query_test.go
+++ b/lib/query/query_test.go
@@ -48,6 +48,22 @@ func TestQuality(t *testing.T) {
 	}
 }
 
+func TestGrayscale(t *testing.T) {
+	q := NewQueryFromGet(getRquest)
+
+	if q.Grayscale() {
+		t.Fatalf("grayscale is true.")
+	}
+}
+
+func TestInverse(t *testing.T) {
+	q := NewQueryFromGet(getRquest)
+
+	if q.Inverse() {
+		t.Fatalf("inverse is true.")
+	}
+}
+
 func TestWebP(t *testing.T) {
 	q := NewQueryFromGet(getRquest)
 


### PR DESCRIPTION
## Thought
Although I'm not pretty sure whether there is demand for these transformation or not, I'd say that they are nice-to-have features as an image-processing web server.

## Grayscale Ms. Lenna
`40ms` (approximately `+0ms`)
![grayscaled_Lenna](https://github.com/user-attachments/assets/4350a203-0935-41c6-a932-1269dfebaa07)

## Inverted Ms. Lenna
`43ms`(approximately `+3ms`)
![inverted_Lenna](https://github.com/user-attachments/assets/ea5ba36a-923a-4ce2-881b-b22ef7d23520)
