### PR TITLE
docs: fix wrong example setting in readme

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,21 +82,21 @@ $ go test -cover ./...
     "use_server_timing": true,
     "providers": [
         {
-            "alias/0" : {
+            "/alias/0" : {
                 "type" : "web",
                 "src" : "http://aaa.com/bbb",
                 "priority" : 10
             }
         },
         {
-            "alias/1" : {
+            "/alias/1" : {
                 "type" : "web",
                 "src" : "https://ccc.com",
                 "priority" : 20
             }
         },
         {
-            "alias/3" : {
+            "/alias/3" : {
                 "type" : "s3",
                 "src" : "s3://bucket/path",
                 "region" : "ap-northeast-1",

--- a/README.md
+++ b/README.md
@@ -73,21 +73,21 @@ On Unix, Linux and macOS, fanlin programs read startup options from the followin
     "use_server_timing": true,
     "providers": [
         {
-            "alias/0" : {
+            "/alias/0" : {
                 "type" : "web",
                 "src" : "http://aaa.com/bbb",
                 "priority" : 10
             }
         },
         {
-            "alias/1" : {
+            "/alias/1" : {
                 "type" : "web",
                 "src" : "https://ccc.com",
                 "priority" : 20
             }
         },
         {
-            "alias/3" : {
+            "/alias/3" : {
                 "type" : "s3",
                 "src" : "s3://bucket/path",
                 "region" : "ap-northeast-1",


### PR DESCRIPTION
Our fanlin requires "leading slash" in the path for the routing. I found that an example setting in readme was wrong. Although it would be better to be complementary by internal process, I fixed the example so far.