### PR TITLE
feat: support HEIF format decoding

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y libaom-dev liblcms2-dev
+          sudo apt install -y libaom-dev liblcms2-dev libheif-dev
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y libaom-dev liblcms2-dev
+          sudo apt install -y libaom-dev liblcms2-dev libheif-dev
 
       - name: Get dependencies
         run: go mod download
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y libaom-dev liblcms2-dev
+          sudo apt install -y libaom-dev liblcms2-dev libheif-dev
 
       - name: Download modules
         run: go mod download
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y libaom-dev liblcms2-dev
+          sudo apt install -y libaom-dev liblcms2-dev libheif-dev
 
       - name: Download modules
         run: go mod download
@@ -113,7 +113,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y libaom-dev liblcms2-dev
+          sudo apt install -y libaom-dev liblcms2-dev libheif-dev
 
       - name: Download modules
         run: go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM golang:1-bookworm AS builder
 RUN set -eux; \
   apt-get update -y; \
-  apt-get install -y --no-install-recommends \
+  apt-get install -y \
     ca-certificates \
     build-essential \
     make \
     libaom-dev \
-    liblcms2-dev
+    liblcms2-dev \
+    libheif-dev
 WORKDIR /usr/src/app
 COPY . .
 RUN make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
     ca-certificates \
-    wget \
-    cmake \
     build-essential \
     libde265-dev \
+    wget \
+    cmake \
     ; \
   wget https://github.com/strukturag/libheif/releases/download/v$VERSION/libheif-$VERSION.tar.gz; \
   tar zxvf libheif-$VERSION.tar.gz; \
@@ -29,18 +29,20 @@ RUN set -eux; \
     liblcms2-dev
 WORKDIR /usr/src/app
 COPY . .
-COPY --from=heif --chmod=644 /usr/local/lib/libheif.so* /lib/x86_64-linux-gnu/
-COPY --from=heif --chmod=644 /usr/local/lib/libheif/* /lib/x86_64-linux-gnu/libheif/
 COPY --from=heif --chmod=644 /usr/local/lib/pkgconfig/libheif.pc /lib/x86_64-linux-gnu/pkgconfig/
-COPY --from=heif --chmod=644 /usr/local/include/libheif/* /usr/include/libheif/
+COPY --from=heif --chmod=644 /usr/local/include/libheif/*        /usr/local/include/libheif/
+COPY --from=heif --chmod=644 /usr/local/lib/libheif.so*          /usr/local/lib/
 RUN make build
 
 # https://github.com/GoogleContainerTools/distroless
 # https://console.cloud.google.com/gcr/images/distroless/GLOBAL
 FROM gcr.io/distroless/cc-debian12:nonroot-amd64
+COPY --from=builder --chmod=755 /usr/src/app/cmd/fanlin/server         /usr/local/bin/fanlin
 COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libaom.so.*      /lib/x86_64-linux-gnu/
 COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/liblcms2.so.*    /lib/x86_64-linux-gnu/
-COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libheif.so*      /lib/x86_64-linux-gnu/
 COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libsharpyuv.so.* /lib/x86_64-linux-gnu/
-COPY --from=builder --chmod=755 /usr/src/app/cmd/fanlin/server         /usr/local/bin/fanlin
+COPY --from=heif    --chmod=644 /lib/x86_64-linux-gnu/libde265.so*     /lib/x86_64-linux-gnu/
+COPY --from=heif    --chmod=644 /usr/local/lib/libheif.so*             /lib/x86_64-linux-gnu/
+COPY --from=heif    --chmod=644 /usr/local/lib/libheif/*               /lib/x86_64-linux-gnu/libheif/plugins/
+ENV LIBHEIF_PLUGIN_PATH=/lib/x86_64-linux-gnu/libheif/plugins
 ENTRYPOINT ["/usr/local/bin/fanlin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,46 @@
+FROM debian:bookworm AS heif
+ARG VERSION=1.19.7
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    ca-certificates \
+    wget \
+    cmake \
+    build-essential \
+    libde265-dev \
+    ; \
+  wget https://github.com/strukturag/libheif/releases/download/v$VERSION/libheif-$VERSION.tar.gz; \
+  tar zxvf libheif-$VERSION.tar.gz; \
+  cd libheif-$VERSION; \
+  mkdir build; \
+  cd build; \
+  cmake --preset=release ..; \
+  make; \
+  make install
+
 FROM golang:1-bookworm AS builder
 RUN set -eux; \
   apt-get update -y; \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
     make \
     libaom-dev \
-    liblcms2-dev \
-    libheif-dev
+    liblcms2-dev
 WORKDIR /usr/src/app
 COPY . .
+COPY --from=heif --chmod=644 /usr/local/lib/libheif.so* /lib/x86_64-linux-gnu/
+COPY --from=heif --chmod=644 /usr/local/lib/libheif/* /lib/x86_64-linux-gnu/libheif/
+COPY --from=heif --chmod=644 /usr/local/lib/pkgconfig/libheif.pc /lib/x86_64-linux-gnu/pkgconfig/
+COPY --from=heif --chmod=644 /usr/local/include/libheif/* /usr/include/libheif/
 RUN make build
 
 # https://github.com/GoogleContainerTools/distroless
 # https://console.cloud.google.com/gcr/images/distroless/GLOBAL
 FROM gcr.io/distroless/cc-debian12:nonroot-amd64
-COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libaom.so.*   /lib/x86_64-linux-gnu/
-COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/liblcms2.so.* /lib/x86_64-linux-gnu/
-COPY --from=builder --chmod=755 /usr/src/app/cmd/fanlin/server      /usr/local/bin/fanlin
+COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libaom.so.*      /lib/x86_64-linux-gnu/
+COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/liblcms2.so.*    /lib/x86_64-linux-gnu/
+COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libheif.so*      /lib/x86_64-linux-gnu/
+COPY --from=builder --chmod=644 /lib/x86_64-linux-gnu/libsharpyuv.so.* /lib/x86_64-linux-gnu/
+COPY --from=builder --chmod=755 /usr/src/app/cmd/fanlin/server         /usr/local/bin/fanlin
 ENTRYPOINT ["/usr/local/bin/fanlin"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,6 +42,13 @@ $ sudo apt install libaom-dev
 $ sudo apt install liblcms2-dev
 ```
 
+さらに、HEIFフォーマット画像のデコードのために以下のライブラリが必要です。
+
+```
+$ sudo apt install libheif-dev
+```
+
+
 ## Linux用にクロスコンパイルする
 ```
 $ GOOS=linux GOARCH=amd64 go build github.com/livesense-inc/fanlin/cmd/fanlin

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,6 @@ $ sudo apt install liblcms2-dev
 $ sudo apt install libheif-dev
 ```
 
-
 ## Linux用にクロスコンパイルする
 ```
 $ GOOS=linux GOARCH=amd64 go build github.com/livesense-inc/fanlin/cmd/fanlin

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Also, we need the following dependency for the conversion between CMYK and RGB c
 $ sudo apt install liblcms2-dev
 ```
 
+Additionally, you need a libheif to decode HEIF format images.
+
+```
+$ sudo apt install libheif-dev
+```
+
 ## Cross compile for amd64 Linux
 ```
 $ GOOS=linux GOARCH=amd64 go build github.com/livesense-inc/fanlin/cmd/fanlin

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.21.1
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/sirupsen/logrus v1.9.3
+	github.com/strukturag/libheif v1.17.6
 	golang.org/x/image v0.25.0
 	golang.org/x/net v0.37.0
 	golang.org/x/text v0.23.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.21.1
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/sirupsen/logrus v1.9.3
-	github.com/strukturag/libheif v1.17.6
+	github.com/strukturag/libheif-go v0.0.0-20250130134905-55b3482bea15
 	golang.org/x/image v0.25.0
 	golang.org/x/net v0.37.0
 	golang.org/x/text v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/strukturag/libheif v1.17.6 h1:UFz4FI7kKLINWyL7bcNEBu4gZxK7rHRkwq49IOzHyvE=
+github.com/strukturag/libheif v1.17.6/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=
 golang.org/x/image v0.25.0 h1:Y6uW6rH1y5y/LK1J8BPWZtr6yZ7hrsy6hFrXjgsc2fQ=
 golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
 golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/strukturag/libheif v1.17.6 h1:UFz4FI7kKLINWyL7bcNEBu4gZxK7rHRkwq49IOzHyvE=
-github.com/strukturag/libheif v1.17.6/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=
+github.com/strukturag/libheif-go v0.0.0-20250130134905-55b3482bea15 h1:aFa2PvtQulG5uVQ8adH84JCwRZ2rjiZnRUU/mWxJRG8=
+github.com/strukturag/libheif-go v0.0.0-20250130134905-55b3482bea15/go.mod h1:ZW0m/zWIvFqFSpPdiWRje8xdwyWJqt3Cnt6bVlDti8g=
 golang.org/x/image v0.25.0 h1:Y6uW6rH1y5y/LK1J8BPWZtr6yZ7hrsy6hFrXjgsc2fQ=
 golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
 golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -22,7 +22,7 @@ import (
 	imgproxyerr "github.com/livesense-inc/fanlin/lib/error"
 	"github.com/livesense-inc/go-lcms/lcms"
 	"github.com/rwcarlsen/goexif/exif"
-	_ "github.com/strukturag/libheif/go/heif"
+	_ "github.com/strukturag/libheif-go"
 	_ "golang.org/x/image/bmp"
 )
 

--- a/lib/image/image.go
+++ b/lib/image/image.go
@@ -22,6 +22,7 @@ import (
 	imgproxyerr "github.com/livesense-inc/fanlin/lib/error"
 	"github.com/livesense-inc/go-lcms/lcms"
 	"github.com/rwcarlsen/goexif/exif"
+	_ "github.com/strukturag/libheif/go/heif"
 	_ "golang.org/x/image/bmp"
 )
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format

Our users occasionally upload HEIF format images to our web services. I guess they may use iPhone. Unfortunately, current fanlin doesn't support HEIF format decoding and returns an error with "unknown format". So, this pull request adds a feature to support HEIF decoding by using the following libraries.

* https://github.com/strukturag/libheif-go
* https://github.com/strukturag/libheif

The above libraries have a LGPL v3 license at this time. However, according to the following issue, it looks like the maintainers will change the license to MIT in the binding library.

* https://github.com/strukturag/libheif/issues/789

> MIT is fine with me.
> Please note that I started moving the Go bindings to a separate repository so they can be developed independently:
> `https://github.com/strukturag/libheif-go`
> I'll update the license there, too.

I'm not pretty sure whether we should change our lisence from MIT to LGPL or not. This pull request merging may need to be wait for the dependent library license changing. On the other hand, it seems that the other binding libraries have various license types.

https://github.com/strukturag/libheif?tab=readme-ov-file#language-bindings

A binding library for Rust has a MIT license.

* https://github.com/Cykooz/libheif-sys
* https://github.com/Cykooz/libheif-rs

Python libraries have Apache or BSD licenses.

* https://github.com/carsales/pyheif
* https://github.com/bigcat88/pillow_heif

A Swift library has no license.
https://github.com/SDWebImage/libheif-Xcode