### PR TITLE
docs: add a badge for DeepWiki

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,7 @@
 # fanlin
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/livesense-inc/fanlin)
 ![Test](https://github.com/livesense-inc/fanlin/actions/workflows/test.yml/badge.svg?branch=master)
 ![Release](https://github.com/livesense-inc/fanlin/actions/workflows/release.yaml/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fanlin
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/livesense-inc/fanlin)
 ![Test](https://github.com/livesense-inc/fanlin/actions/workflows/test.yml/badge.svg?branch=master)
 ![Release](https://github.com/livesense-inc/fanlin/actions/workflows/release.yaml/badge.svg)
 


### PR DESCRIPTION
https://deepwiki.com/livesense-inc/fanlin

DeepWiki says:

> Add a badge to this wiki in the repo's README file to auto refresh the wiki weekly with the latest code.

This pull request adds a badge for DeepWiki to README files so that the document generated by DeepWiki is kept to be fresh.